### PR TITLE
doc: reflects that cursorline can be set via `setup.win_options`

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ require("oil").setup({
   win_options = {
     wrap = false,
     signcolumn = "no",
+    -- cursorline = true, -- will pick user's settings if not set.
     cursorcolumn = false,
     foldcolumn = "0",
     spell = false,


### PR DESCRIPTION
My intention is that I didn't know that I can set `cursorline` by `setup.win_options`, so making this PR for helping people having the same question in mind. I didn't touch anything in your code.