### PR TITLE
Respect 'clipboard' in copy_entry_path

### DIFF
--- a/lua/oil/actions.lua
+++ b/lua/oil/actions.lua
@@ -199,7 +199,7 @@ M.copy_entry_path = {
     if not entry or not dir then
       return
     end
-    vim.fn.setreg("+", dir .. entry.name)
+    vim.fn.setreg(vim.v.register, dir .. entry.name)
   end,
 }
 


### PR DESCRIPTION
Using `vim.v.register`, we can respect the user's desire of copying to the unnamed (or unnamedplus) register or default one.

Check `:h v:register`

Thanks!