### PR TITLE
fix: oil-ssh assume target machine's locales

### DIFF
--- a/lua/oil/adapters/ssh/sshfs.lua
+++ b/lua/oil/adapters/ssh/sshfs.lua
@@ -120,7 +120,7 @@ function SSHFS:list_dir(url, path, callback)
   if path ~= "" then
     path_postfix = string.format(" '%s'", path)
   end
-  self.conn:run("ls -fl" .. path_postfix, function(err, lines)
+  self.conn:run("LANG=C ls -fl" .. path_postfix, function(err, lines)
     if err then
       if err:match("No such file or directory%s*$") then
         -- If the directory doesn't exist, treat the list as a success. We will be able to traverse


### PR DESCRIPTION
Currently `oil-ssh` will raise an error if target machine do not use english locales:
```
...e/nvim/site/lazy/oil.nvim/lua/oil/adapters/ssh/sshfs.lua:25: Could
 not parse '总用量 116'
stack traceback:
^I[C]: in function 'error'
^I...e/nvim/site/lazy/oil.nvim/lua/oil/adapters/ssh/sshfs.lua:25: in
function 'parse_ls_line'
^I...e/nvim/site/lazy/oil.nvim/lua/oil/adapters/ssh/sshfs.lua:137: in
 function 'cb'
^I...m/site/lazy/oil.nvim/lua/oil/adapters/ssh/connection.lua:199: in
 function '_handle_output'
^I...m/site/lazy/oil.nvim/lua/oil/adapters/ssh/connection.lua:102: in
 function <...m/site/lazy/oil.nvim/lua/oil/adapters/ssh/connection.lu
a:99>
```