### PR TITLE
Escape dollar sign

### DIFF
--- a/lua/oil/util.lua
+++ b/lua/oil/util.lua
@@ -12,7 +12,7 @@ end
 ---@param filename string
 ---@return string
 M.escape_filename = function(filename)
-  local ret = filename:gsub("([%%#])", "\\%1")
+  local ret = filename:gsub("([%%#$])", "\\%1")
   return ret
 end
 


### PR DESCRIPTION
This fixes an issue where a folder named `products.$id` gets evaluated to `products.<value of 'id' env var>`. 