### PR TITLE
(feat) Added override function for floatwin

### DIFF
--- a/lua/oil/config.lua
+++ b/lua/oil/config.lua
@@ -80,6 +80,19 @@ local default_config = {
     win_options = {
       winblend = 10,
     },
+    -- This is the config that will be passed to nvim_open_win.
+    -- Change values here to customize the layout
+    -- For example, you can use this to position the window on the right
+    -- override = function(conf)
+    --   local opts = {
+    --     col = vim.o.columns - conf.width,
+    --     zindex = 80,
+    --   }
+    --   return vim.tbl_deep_extend("force", conf, opts)
+    -- end,
+    override = function(conf)
+      return conf
+    end,
   },
   -- Configuration for the actions floating preview window
   preview = {

--- a/lua/oil/init.lua
+++ b/lua/oil/init.lua
@@ -273,6 +273,7 @@ M.open_float = function(dir)
     border = config.float.border,
     zindex = 45,
   }
+  win_opts = config.float.override(win_opts)
 
   local winid = vim.api.nvim_open_win(bufnr, true, win_opts)
   vim.w[winid].is_oil_win = true
@@ -325,10 +326,10 @@ M.open_float = function(dir)
           end
           vim.api.nvim_win_set_config(winid, {
             relative = "editor",
-            row = row,
-            col = col,
-            width = width,
-            height = height,
+            row = win_opts.row,
+            col = win_opts.col,
+            width = win_opts.width,
+            height = win_opts.height,
             title = get_title(),
           })
         end,


### PR DESCRIPTION
My previous pull request was accidentally closed after I rebased my repository. I have now added an override function for the floating window, allowing us to override the float options as shown below.
```lua
float = {
  padding = 0,
  max_width = 40,
  override = function(conf)
    local opts = {
      col = vim.o.columns - conf.width,
      zindex = 80,
    }
    return vim.tbl_deep_extend("force", conf, opts)
  end,
}
```