### PR TITLE
Use default directory config when opening directories

### DIFF
--- a/lua/oil/init.lua
+++ b/lua/oil/init.lua
@@ -815,7 +815,8 @@ M.setup = function(opts)
     M[method](unpack(args.fargs))
   end, { desc = "Open oil file browser on a directory", nargs = "*", complete = "dir" })
   local aug = vim.api.nvim_create_augroup("Oil", {})
-  if vim.fn.exists("#FileExplorer") then
+
+  if config.default_file_explorer and vim.fn.exists("#FileExplorer") then
     vim.api.nvim_create_augroup("FileExplorer", { clear = true })
   end
 


### PR DESCRIPTION
I was experiencing a bug where if I open a folder using `vim .`, the directory would still be opened with oil, even though I set default_file_explorer to false.

> I haven't tried recreating this bug with a minimal config yet. 

my config using packer:
```lua
    use {
        'stevearc/oil.nvim',
        config = function()
            require('oil').setup({
                columns = {
                    "icon",
                },
                default_file_explorer = false,
            })
        end
    }
```