### PR TITLE
Use standard directory highlight group

### DIFF
--- a/lua/oil/init.lua
+++ b/lua/oil/init.lua
@@ -610,7 +610,7 @@ M._get_highlights = function()
   return {
     {
       name = "OilDir",
-      link = "Special",
+      link = "Directory",
       desc = "Directories in an oil buffer",
     },
     {


### PR DESCRIPTION
I'm not sure if this was intentional or not, but there is a specific highlight group for directories.
(This highlight group is used by other plugins e.g. netrw, nvim-tree)