### PR TITLE
Use /bin/sh instead of bash.

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ nvim oil-ssh://[username@]hostname[:port]/[path]
 
 This may look familiar. In fact, this is the same url format that netrw uses.
 
-Note that at the moment the ssh adapter does not support Windows machines, and it requires the server to have a `/bin/bash` binary as well as standard unix commands (`rm`, `mv`, `mkdir`, `chmod`, `cp`, `touch`, `ln`, `echo`).
+Note that at the moment the ssh adapter does not support Windows machines, and it requires the server to have a `/bin/sh` binary as well as standard unix commands (`rm`, `mv`, `mkdir`, `chmod`, `cp`, `touch`, `ln`, `echo`).
 
 ## API
 

--- a/lua/oil/adapters/ssh/connection.lua
+++ b/lua/oil/adapters/ssh/connection.lua
@@ -71,12 +71,11 @@ end
 function SSHConnection.new(url)
   local command = SSHConnection.create_ssh_command(url)
   vim.list_extend(command, {
-    "/bin/bash",
-    "--norc",
+    "/bin/sh",
     "-c",
     -- HACK: For some reason in my testing if I just have "echo READY" it doesn't appear, but if I echo
     -- anything prior to that, it *will* appear. The first line gets swallowed.
-    "echo '_make_newline_'; echo '===READY==='; exec /bin/bash --norc",
+    "echo '_make_newline_'; echo '===READY==='; exec /bin/sh",
   })
   local term_bufnr = vim.api.nvim_create_buf(false, true)
   local self = setmetatable({

--- a/tests/url_spec.lua
+++ b/tests/url_spec.lua
@@ -4,7 +4,7 @@ describe("url", function()
   it("get_url_for_path", function()
     local cases = {
       { "", "oil://" .. util.addslash(vim.fn.getcwd()) },
-      { "term://~/oil.nvim//52953:/bin/bash", "oil://" .. vim.loop.os_homedir() .. "/oil.nvim/" },
+      { "term://~/oil.nvim//52953:/bin/sh", "oil://" .. vim.loop.os_homedir() .. "/oil.nvim/" },
       { "/foo/bar.txt", "oil:///foo/", "bar.txt" },
       { "oil:///foo/bar.txt", "oil:///foo/", "bar.txt" },
       { "oil:///", "oil:///" },


### PR DESCRIPTION
This allows support of other *nix operating systems where bash is not universally present.

.... I routinely use both FreeBSD and Linux.  In FreeBSD, there is no `/bin/bash` -- if it's installed at all via ports, it's under `/usr/local/bin/bash`.

Switching this to `/bin/sh` seems to work fine with some rudimentary usage between various operating systems.   (On most Linuxes, this is bash anyway.  Or Dash.  Or something bash-like.  On the *BSDs, this is Bourne.  In any event, Oil appears to work across the board so far, and I'm pleased to be able to use it across platforms.