### PR TITLE
Escape metacharacters when loading file into cmdline

### DIFF
--- a/lua/oil/actions.lua
+++ b/lua/oil/actions.lua
@@ -225,12 +225,8 @@ M.refresh = {
 }
 
 local function open_cmdline_with_path(path)
-  local escaped = vim.api.nvim_replace_termcodes(
-    ": " .. vim.fn.fnameescape(path) .. "<Home>",
-    true,
-    false,
-    true
-  )
+  local escaped =
+    vim.api.nvim_replace_termcodes(": " .. vim.fn.fnameescape(path) .. "<Home>", true, false, true)
   vim.api.nvim_feedkeys(escaped, "n", false)
 end
 

--- a/lua/oil/actions.lua
+++ b/lua/oil/actions.lua
@@ -224,14 +224,14 @@ M.refresh = {
   end,
 }
 
-local function open_cmdline_with_args(args)
+local function open_cmdline_with_path(path)
   local escaped = vim.api.nvim_replace_termcodes(
-    ": " .. args .. string.rep("<Left>", args:len() + 1),
+    ": " .. vim.fn.fnameescape(path) .. "<Home>",
     true,
     false,
     true
   )
-  vim.api.nvim_feedkeys(escaped, "n", true)
+  vim.api.nvim_feedkeys(escaped, "n", false)
 end
 
 M.open_cmdline = {
@@ -253,7 +253,7 @@ M.open_cmdline = {
       return
     end
     local fullpath = fs.shorten_path(fs.posix_to_os_path(path) .. entry.name)
-    open_cmdline_with_args(fullpath)
+    open_cmdline_with_path(fullpath)
   end,
 }
 
@@ -275,7 +275,7 @@ M.open_cmdline_dir = {
     local fs = require("oil.fs")
     local dir = oil.get_current_dir()
     if dir then
-      open_cmdline_with_args(fs.shorten_path(dir))
+      open_cmdline_with_path(fs.shorten_path(dir))
     end
   end,
 }


### PR DESCRIPTION
Small updates for actions `open_cmd_line` and `open_cmdline_dir`.

- Escape special characters in the file path with `fnameescape()` .
- Invoke `nvim_feedkeys()` with `escape_ks=false` as suggested in `:h nvim_feedkeys()` (otherwise there may be problems when file path contains non-ANSCII character).
