### PR TITLE
Add win_options.number to readme to show line number column in --float mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ require("oil").setup({
     list = false,
     conceallevel = 3,
     concealcursor = "nvic",
+    number = false,
   },
   -- Send deleted files to the trash instead of permanently deleting them (:help oil-trash)
   delete_to_trash = false,

--- a/doc/oil.txt
+++ b/doc/oil.txt
@@ -40,6 +40,7 @@ OPTIONS                                                              *oil-option
         list = false,
         conceallevel = 3,
         concealcursor = "nvic",
+        number = false,
       },
       -- Send deleted files to the trash instead of permanently deleting them (:help oil-trash)
       delete_to_trash = false,


### PR DESCRIPTION
I went hunting through the readme and `:h oil` for how to get line numbers in a --float and couldn't find it, just randomly tried flipping all the win_options and then tried adding `number = true` and it worked!

Just wanted to show it as an option in the readme :)