### PR TITLE
feat: make ".." available in file entries

### DIFF
--- a/lua/oil/adapters/files.lua
+++ b/lua/oil/adapters/files.lua
@@ -284,6 +284,8 @@ M.list = function(url, column_defs, cb)
           end)
           return
         elseif entries then
+          -- HACK: manually insert ".." to the list of entries
+          table.insert(entries, { name = "..", type = "directory" });
           local poll = util.cb_collect(#entries, function(inner_err)
             if inner_err then
               cb(inner_err)

--- a/lua/oil/adapters/files.lua
+++ b/lua/oil/adapters/files.lua
@@ -278,12 +278,18 @@ M.list = function(url, column_defs, cb)
     read_next = function()
       uv.fs_readdir(fd, function(err, entries)
         local internal_entries = {}
+        local is_empty = false
         if err then
           uv.fs_closedir(fd, function()
             cb(err)
           end)
           return
-        elseif entries then
+        else
+          -- turn nil to {} so that we can still insert ".."
+          if entries == nil then
+            is_empty = true
+            entries = {}
+          end
           -- HACK: manually insert ".." to the list of entries
           table.insert(entries, { name = "..", type = "directory" });
           local poll = util.cb_collect(#entries, function(inner_err)
@@ -322,7 +328,8 @@ M.list = function(url, column_defs, cb)
               end
             end)
           end
-        else
+        end
+        if is_empty then
           uv.fs_closedir(fd, function(close_err)
             if close_err then
               cb(close_err)


### PR DESCRIPTION
- will close #166 

achieved this by manually adding ".." to the entries of the listed files

```lua
...
table.insert(entries, { name = "..", type = "directory" });
...
```

by default, it will be grouped with the hidden file, but you can make it always shown by setting the `is_hidden_file` function in the user config
```lua
  view_options = {

    -- ...

    is_hidden_file = function(name, bufnr)
      return (name ~= "..") and vim.startswith(name, ".")
    end,

    -- ...

  },
```

not sure if there are any bad side effects,