### PR TITLE
feat: auto-save files affected by will_rename_files

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,9 @@ require("oil").setup({
   -- You can set the delay to false to disable cleanup entirely
   -- Note that the cleanup process only starts when none of the oil buffers are currently displayed
   cleanup_delay_ms = 2000,
+  -- Set to true to autosave buffers that are updated with LSP willRenameFiles
+  -- Set to "unmodified" to only save unmodified buffers
+  lsp_rename_autosave = false,
   -- Keymaps in oil buffer. Can be any value that `vim.keymap.set` accepts OR a table of keymap
   -- options with a `callback` (e.g. { callback = function() ... end, desc = "", mode = "n" })
   -- Additionally, if it is a string that matches "actions.<name>",

--- a/doc/oil.txt
+++ b/doc/oil.txt
@@ -52,6 +52,9 @@ OPTIONS                                                              *oil-option
       -- You can set the delay to false to disable cleanup entirely
       -- Note that the cleanup process only starts when none of the oil buffers are currently displayed
       cleanup_delay_ms = 2000,
+      -- Set to true to autosave buffers that are updated with LSP willRenameFiles
+      -- Set to "unmodified" to only save unmodified buffers
+      lsp_rename_autosave = false,
       -- Keymaps in oil buffer. Can be any value that `vim.keymap.set` accepts OR a table of keymap
       -- options with a `callback` (e.g. { callback = function() ... end, desc = "", mode = "n" })
       -- Additionally, if it is a string that matches "actions.<name>",

--- a/lua/oil/config.lua
+++ b/lua/oil/config.lua
@@ -38,6 +38,9 @@ local default_config = {
   -- You can set the delay to false to disable cleanup entirely
   -- Note that the cleanup process only starts when none of the oil buffers are currently displayed
   cleanup_delay_ms = 2000,
+  -- Set to true to autosave buffers that are updated with LSP willRenameFiles
+  -- Set to "unmodified" to only save unmodified buffers
+  lsp_rename_autosave = false,
   -- Keymaps in oil buffer. Can be any value that `vim.keymap.set` accepts OR a table of keymap
   -- options with a `callback` (e.g. { callback = function() ... end, desc = "", mode = "n" })
   -- Additionally, if it is a string that matches "actions.<name>",

--- a/lua/oil/lsp_helpers.lua
+++ b/lua/oil/lsp_helpers.lua
@@ -89,6 +89,13 @@ M.will_rename_files = function(actions)
       }, function(_, result)
         if result then
           vim.lsp.util.apply_workspace_edit(result, client.offset_encoding)
+          for uri, _ in pairs(result.changes) do
+            local bufnr = vim.uri_to_bufnr(uri)
+            vim.api.nvim_buf_call(bufnr, function()
+              vim.cmd("w")
+            end)
+            vim.api.nvim_buf_delete(bufnr, { force = true }) -- This line will close the buffer
+          end
         end
       end)
     end


### PR DESCRIPTION
When moving or renaming files, my expectation was for all files referencing the changed file to be updated and written in the background. The current implementation seems to open all affected files in buffers, though each buffer needs to be manually written for the job to feel 'complete'.

This proposed change writes all affected buffers after `apply_workspace_edit` has executed. It then deletes all buffers that didn't exist prior to the move/rename action.