### PR TITLE
feat: compatible with `CTRL-L-default`

### DIFF
--- a/lua/oil/actions.lua
+++ b/lua/oil/actions.lua
@@ -224,6 +224,9 @@ M.refresh = {
       end
     end
     vim.cmd.edit({ bang = true })
+
+    -- :h CTRL-L-default
+    vim.cmd.nohlsearch()
   end,
 }
 


### PR DESCRIPTION
`<C-l>` is used to refresh the current directory, which is a good design. But there is a `CTRL-L-default` in neovim, which makes `<C-l>` a shortcut to execute `:nohlsearch`. I recommend respecting it to make oil like a real normal file.