### PR TITLE
fix: allow bare function `require("oil").open` as argument to `nvim_create_user_command`

### DIFF
--- a/lua/oil/init.lua
+++ b/lua/oil/init.lua
@@ -165,7 +165,7 @@ M.get_url_for_path = function(dir, use_oil_parent)
   if vim.bo.filetype == "netrw" and not dir then
     dir = vim.b.netrw_curdir
   end
-  if dir then
+  if type(dir) == "string" then
     local scheme = util.parse_url(dir)
     if scheme then
       return dir


### PR DESCRIPTION
I tried to define a user command like this:

```lua
local oil = require("oil")
vim.api.nvim_create_user_command(
	"Ex",
	oil.open,
	{ desc = "Open file browser" }
)
```

But I got this error:

```
E492: Not an editor command: Oil
Error executing Lua callback: ...garrett/.local/share/nvim/lazy/oil.nvim/lua/oil/util.lua:15: attempt to call method 'match' (a nil value)
stack traceback:
        ...garrett/.local/share/nvim/lazy/oil.nvim/lua/oil/util.lua:15: in function 'parse_url'
        ...garrett/.local/share/nvim/lazy/oil.nvim/lua/oil/init.lua:169: in function 'get_url_for_path'
        ...garrett/.local/share/nvim/lazy/oil.nvim/lua/oil/init.lua:367: in function <...garrett/.local/share/nvim/lazy/oil.nvim/lua/oil/init.lua:363>
```

Wrapping it in an anonymous function resolves the issue:

```lua
local oil = require("oil")
vim.api.nvim_create_user_command(
	"Ex",
	function() oil.open() end,
	{ desc = "Open file browser" }
)
```

The reason seems to be that `open` expects a nil or a string. But when a function is used to define a user command it receives a table of information as an argument.

This PR checks to make sure the argument is a string instead of just checking to make sure it's not nil.