### PR TITLE
feat: allow multiple hlgroups inside one column

### DIFF
--- a/lua/oil/init.lua
+++ b/lua/oil/init.lua
@@ -7,7 +7,7 @@ local M = {}
 ---@field parsed_name nil|string
 
 ---@alias oil.EntryType "file"|"directory"|"socket"|"link"|"fifo"
----@alias oil.TextChunk string|string[]
+---@alias oil.TextChunk string|string[]|{ [1]: string, [2]: { [1]: string, [2]: integer, [3]: integer }[] }
 ---@alias oil.CrossAdapterAction "copy"|"move"
 
 ---@class (exact) oil.Adapter

--- a/lua/oil/init.lua
+++ b/lua/oil/init.lua
@@ -7,7 +7,10 @@ local M = {}
 ---@field parsed_name nil|string
 
 ---@alias oil.EntryType "file"|"directory"|"socket"|"link"|"fifo"
----@alias oil.TextChunk string|string[]|{ [1]: string, [2]: { [1]: string, [2]: integer, [3]: integer }[] }
+---@alias oil.HlRange { [1]: string, [2]: integer, [3]: integer } A tuple of highlight group name, col_start, col_end
+---@alias oil.HlTuple { [1]: string, [2]: string } A tuple of text, highlight group
+---@alias oil.HlRangeTuple { [1]: string, [2]: oil.HlRange[] } A tuple of text, internal highlights
+---@alias oil.TextChunk string|oil.HlTuple|oil.HlRangeTuple
 ---@alias oil.CrossAdapterAction "copy"|"move"
 
 ---@class (exact) oil.Adapter

--- a/lua/oil/util.lua
+++ b/lua/oil/util.lua
@@ -302,7 +302,21 @@ M.render_table = function(lines, col_width)
       table.insert(pieces, text)
       local col_end = col + text:len() + 1
       if hl then
-        table.insert(highlights, { hl, #str_lines, col, col_end })
+        if type(hl) == "table" then
+          -- hl has the form { [1]: hl_name, [2]: col_start, [3]: col_end }[]
+          -- Notice that col_start and col_end are relative position inside
+          -- that col, so we need to add the offset to them
+          for _, sub_hl in ipairs(hl) do
+            table.insert(highlights, {
+              sub_hl[1],
+              #str_lines,
+              col + sub_hl[2],
+              col + sub_hl[3],
+            })
+          end
+        else
+          table.insert(highlights, { hl, #str_lines, col, col_end })
+        end
       end
       col = col_end
     end

--- a/lua/oil/util.lua
+++ b/lua/oil/util.lua
@@ -294,7 +294,8 @@ M.render_table = function(lines, col_width)
     for i, chunk in ipairs(cols) do
       local text, hl
       if type(chunk) == "table" then
-        text, hl = unpack(chunk)
+        text = chunk[1]
+        hl = chunk[2]
       else
         text = chunk
       end


### PR DESCRIPTION
This PR adds the ability to set multiple hlgroups inside one column.

Related to https://github.com/stevearc/oil.nvim/issues/212

Before:

![image](https://github.com/stevearc/oil.nvim/assets/76579810/f3e12856-fff6-4cf1-9dec-c718510d5eab)

After:

![image](https://github.com/stevearc/oil.nvim/assets/76579810/53f75d9c-d7b2-497c-b9b4-9fb4a0d075a8)

To achieve the effect of the second screenshot, one has to setup oil as follows:

```lua
local permission_hlgroups = {
  ['-'] = 'NonText',
  ['r'] = 'DiagnosticSignWarn',
  ['w'] = 'DiagnosticSignError',
  ['x'] = 'DiagnosticSignOk',
}

oil.setup({
  columns = {
    {
      'permissions',
      highlight = function(permission_str)
        local hls = {}
        for i = 1, #permission_str do
          local char = permission_str:sub(i, i)
          table.insert(hls, { permission_hlgroups[char], i - 1, i })
        end
        return hls
      end,
    },
    { 'size', highlight = 'Special' },
    { 'mtime', highlight = 'Number' },
    {
      'icon',
      default_file = icon_file,
      directory = icon_dir,
      add_padding = false,
    },
  },
  win_options = {
    number = false,
    relativenumber = false,
    signcolumn = 'no',
    foldcolumn = '0',
    statuscolumn = '',
  },
})
```
