### PR TITLE
feat(windows-trash): support for deleting to windows trash

### DIFF
--- a/lua/oil/adapters/trash.lua
+++ b/lua/oil/adapters/trash.lua
@@ -3,7 +3,7 @@ local fs = require("oil.fs")
 if fs.is_mac then
   return require("oil.adapters.trash.mac")
 elseif fs.is_windows then
-  error("Trash is not implemented yet on Windows")
+  return require("oil.adapters.trash.windows")
 else
   return require("oil.adapters.trash.freedesktop")
 end

--- a/lua/oil/adapters/trash/windows.lua
+++ b/lua/oil/adapters/trash/windows.lua
@@ -21,7 +21,7 @@ else
   powershell_date_grammar = {
     ---@param input string
     ---@return integer
-    match = function(input)
+    match = function(self, input)
       return input:match("/Date%((%d+)%)/")
     end,
   }

--- a/lua/oil/adapters/trash/windows.lua
+++ b/lua/oil/adapters/trash/windows.lua
@@ -182,6 +182,12 @@ M.is_modifiable = function(_bufnr)
   return true
 end
 
+local current_year
+-- Make sure we run this import-time effect in the main loop (mostly for tests)
+vim.schedule(function()
+  current_year = vim.fn.strftime("%Y")
+end)
+
 local file_columns = {}
 file_columns.mtime = {
   render = function(entry, conf)

--- a/lua/oil/adapters/trash/windows.lua
+++ b/lua/oil/adapters/trash/windows.lua
@@ -8,42 +8,41 @@ local fs = require("oil.fs")
 
 local FIELD_META = constants.FIELD_META
 
-local powershell_date_grammar
-if vim.fn.has("nvim-0.10") == 1 then
-  local P, R, V = vim.lpeg.P, vim.lpeg.R, vim.lpeg.V
-
-  powershell_date_grammar = P({
-    "date",
-    delimiter = P("/"),
-    date = V("delimiter") * P("Date(") * (R("09") ^ 1 / tonumber) * P(")") * V("delimiter"),
-  })
-else
-  powershell_date_grammar = {
-    ---@param input string
-    ---@return integer?
-    match = function(self, input)
-      return tonumber(input:match("/Date%((%d+)%)/"))
-    end,
-  }
-end
-
--- Work in progress
 local M = {}
 
----@param line string
 ---@return string
-local remove_cr = function(line)
-  local result = line:gsub("\r", "")
-  return result
+local function get_trash_dir()
+  local cwd = assert(vim.fn.getcwd())
+  local trash_dir = cwd:sub(1, 3) .. "$Recycle.Bin"
+  if vim.fn.isdirectory(trash_dir) == 1 then
+    return trash_dir
+  end
+  trash_dir = "C:\\$Recycle.Bin"
+  if vim.fn.isdirectory(trash_dir) == 1 then
+    return trash_dir
+  end
+  error("No trash found")
 end
 
----@param url string
----@param column_defs string[]
----@param cb fun(err?: string, entries?: oil.InternalEntry[], fetch_more?: fun())
-M.list = function(url, column_defs, cb)
-  local _, path = util.parse_url(url)
-  assert(path)
+---@param path string
+---@return string
+local win_addslash = function(path)
+  if not vim.endswith(path, "\\") then
+    return path .. "\\"
+  else
+    return path
+  end
+end
 
+---@class oil.WindowsRawEntry
+---@field IsFolder boolean
+---@field DeletionDate integer
+---@field Name string
+---@field Path string
+---@field OriginalPath string
+
+---@param cb fun(err?: string, raw_entries: oil.WindowsRawEntry[]?)
+local get_raw_entries = function(cb)
   ---@type string?
   local stdout
 
@@ -53,14 +52,18 @@ M.list = function(url, column_defs, cb)
     "-ExecutionPolicy",
     "Bypass",
     "-Command",
+    -- The first line configures Windows Powershell to use UTF-8 for input and output
+    -- 0xa is the constant for Recycle Bin. See https://learn.microsoft.com/en-us/windows/win32/api/shldisp/ne-shldisp-shellspecialfolderconstants
     [[
+$OutputEncoding = [Console]::InputEncoding = [Console]::OutputEncoding = New-Object System.Text.UTF8Encoding
 $shell = New-Object -ComObject 'Shell.Application'
 $folder = $shell.NameSpace(0xa)
 $data = @(foreach ($i in $folder.items())
     {
         @{
             IsFolder=$i.IsFolder;
-            ModifyDate=$i.ModifyDate;Name=$i.Name;
+            DeletionDate=([DateTimeOffset]$i.extendedproperty('datedeleted')).ToUnixTimeSeconds();
+            Name=$i.Name;
             Path=$i.Path;
             OriginalPath=-join($i.ExtendedProperty('DeletedFrom'), "\", $i.Name)
         }
@@ -70,7 +73,7 @@ ConvertTo-Json $data
   }, {
     stdout_buffered = true,
     on_stdout = function(_, data)
-      stdout = table.concat(vim.tbl_map(remove_cr, data), "\n")
+      stdout = table.concat(data, "\n")
     end,
     on_exit = function(_, code)
       if code ~= 0 then
@@ -78,28 +81,7 @@ ConvertTo-Json $data
       end
       assert(stdout)
       local raw_entries = vim.json.decode(stdout)
-      local entries = vim.tbl_map(
-        ---@param entry {IsFolder: boolean, ModifyDate: string, Name: string, Path: string, OriginalPath: string}
-        ---@return {[1]:nil, [2]:string, [3]:string, [4]:{stat: uv_fs_t, trash_info: oil.TrashInfo, display_name: string}}
-        function(entry)
-          local cache_entry =
-            cache.create_entry(url, entry.Name, entry.IsFolder and "directory" or "file")
-          cache_entry[FIELD_META] = {
-            stat = nil,
-            trash_info = {
-              trash_file = entry.Path,
-              info_file = nil,
-              original_path = entry.OriginalPath,
-              deletion_date = powershell_date_grammar:match(entry.ModifyDate),
-              stat = nil,
-            },
-            display_name = entry.Name,
-          }
-          return cache_entry
-        end,
-        raw_entries
-      )
-      cb(nil, entries)
+      cb(nil, raw_entries)
     end,
   })
   if jid <= 0 then
@@ -107,48 +89,151 @@ ConvertTo-Json $data
   end
 end
 
---TODO: is this ok?
+---@class oil.WindowsTrashInfo
+---@field trash_file string?
+---@field original_path string?
+---@field deletion_date string?
+
+---@param url string
+---@param column_defs string[]
+---@param cb fun(err?: string, entries?: oil.InternalEntry[], fetch_more?: fun())
+M.list = function(url, column_defs, cb)
+  local _, path = util.parse_url(url)
+  path = fs.posix_to_os_path(assert(path))
+
+  local trash_dir = get_trash_dir()
+  local show_all_files = fs.is_subpath(path, trash_dir)
+
+  get_raw_entries(function(err, raw_entries)
+    if err then
+      cb(err)
+      return
+    end
+
+    local entries = vim.tbl_map(
+      ---@param entry {IsFolder: boolean, DeletionDate: integer, Name: string, Path: string, OriginalPath: string}
+      ---@return {[1]:nil, [2]:string, [3]:string, [4]:{stat: uv_fs_t, trash_info: oil.WindowsTrashInfo, display_name: string}}
+      function(entry)
+        local parent = win_addslash(assert(vim.fn.fnamemodify(entry.OriginalPath, ":h")))
+
+        --- @type oil.InternalEntry
+        local cache_entry
+        if path == parent or show_all_files then
+          local unique_name = assert(vim.fn.fnamemodify(entry.Path, ":t"))
+          cache_entry =
+            cache.create_entry(url, unique_name, entry.IsFolder and "directory" or "file")
+          cache_entry[FIELD_META] = {
+            stat = nil,
+            trash_info = {
+              trash_file = entry.Path,
+              original_path = entry.OriginalPath,
+              deletion_date = entry.DeletionDate,
+            },
+            display_name = entry.Name,
+          }
+        end
+        if path ~= parent and (show_all_files or fs.is_subpath(path, parent)) then
+          local name = parent:sub(path:len() + 1)
+          local next_par = vim.fs.dirname(name)
+          while next_par ~= "." do
+            name = next_par
+            next_par = vim.fs.dirname(name)
+            cache_entry = cache.create_entry(url, name, "directory")
+
+            cache_entry[FIELD_META] = {}
+          end
+        end
+        return cache_entry
+      end,
+      raw_entries
+    )
+    cb(nil, entries)
+  end)
+end
+
 M.is_modifiable = function(_bufnr)
   return true
 end
 
--- TODO: do something similar?
--- local file_columns = {}
--- file_columns.mtime = {
---   render = function(entry, conf)
---     local meta = entry[FIELD_META]
---     if not meta then
---       return nil
---     end
---     ---@type oil.TrashInfo
---     local trash_info = meta.trash_info
---     local time = trash_info and trash_info.deletion_date or meta.stat and meta.stat.mtime.sec
---     if not time then
---       return nil
---     end
---     local fmt = conf and conf.format
---     local ret
---     if fmt then
---       ret = vim.fn.strftime(fmt, time)
---     else
---       local year = vim.fn.strftime("%Y", time)
---       if year ~= current_year then
---         ret = vim.fn.strftime("%b %d %Y", time)
---       else
---         ret = vim.fn.strftime("%b %d %H:%M", time)
---       end
---     end
---     return ret
---   end,
+local file_columns = {}
+file_columns.mtime = {
+  render = function(entry, conf)
+    local meta = entry[FIELD_META]
+    if not meta then
+      return nil
+    end
+    ---@type oil.WindowsTrashInfo
+    local trash_info = meta.trash_info
+    local time = trash_info and trash_info.deletion_date
+    if not time then
+      return nil
+    end
+    local fmt = conf and conf.format
+    local ret
+    if fmt then
+      ret = vim.fn.strftime(fmt, time)
+    else
+      local year = vim.fn.strftime("%Y", time)
+      if year ~= current_year then
+        ret = vim.fn.strftime("%b %d %Y", time)
+      else
+        ret = vim.fn.strftime("%b %d %H:%M", time)
+      end
+    end
+    return ret
+  end,
 
---TODO: is this ok?
+  get_sort_value = function(entry)
+    local meta = entry[FIELD_META]
+    ---@type oil.WindowsTrashInfo
+    local trash_info = meta.trash_info
+    if trash_info and trash_info.deletion_date then
+      return trash_info.deletion_date
+    else
+      return 0
+    end
+  end,
+
+  parse = function(line, conf)
+    local fmt = conf and conf.format
+    local pattern
+    if fmt then
+      pattern = fmt:gsub("%%.", "%%S+")
+    else
+      pattern = "%S+%s+%d+%s+%d%d:?%d%d"
+    end
+    return line:match("^(" .. pattern .. ")%s+(.+)$")
+  end,
+}
+
 ---@param name string
 ---@return nil|oil.ColumnDefinition
 M.get_column = function(name)
-  return nil
+  return file_columns[name]
 end
 
---TODO: is this ok?
+---@param action oil.Action
+---@return boolean
+M.filter_action = function(action)
+  if action.type == "create" then
+    return false
+  elseif action.type == "delete" then
+    local entry = assert(cache.get_entry_by_url(action.url))
+    local meta = entry[FIELD_META]
+    return meta.trash_info ~= nil
+  elseif action.type == "move" then
+    local src_adapter = assert(config.get_adapter_by_scheme(action.src_url))
+    local dest_adapter = assert(config.get_adapter_by_scheme(action.dest_url))
+    return src_adapter.name == "files" or dest_adapter.name == "files"
+  elseif action.type == "copy" then
+    local src_adapter = assert(config.get_adapter_by_scheme(action.src_url))
+    local dest_adapter = assert(config.get_adapter_by_scheme(action.dest_url))
+    return src_adapter.name == "files" or dest_adapter.name == "files"
+  else
+    error(string.format("Bad action type '%s'", action.type))
+  end
+end
+
 ---@param url string
 ---@param callback fun(url: string)
 M.normalize_url = function(url, callback)
@@ -170,24 +255,37 @@ end
 ---@param cb fun(path: string)
 M.get_entry_path = function(url, entry, cb)
   local internal_entry = assert(cache.get_entry_by_id(entry.id))
-  local meta = internal_entry[FIELD_META] --[[@as {stat: uv_fs_t, trash_info: oil.TrashInfo, display_name: string}]]
+  local meta = internal_entry[FIELD_META] --[[@as {stat: uv_fs_t, trash_info: oil.WindowsTrashInfo, display_name: string}]]
   local trash_info = meta.trash_info
+  if not trash_info then
+    -- This is a subpath in the trash
+    M.normalize_url(url, cb)
+    return
+  end
 
   local path = fs.os_to_posix_path(trash_info.trash_file)
   if entry.type == "directory" then
-    path = util.addslash(path)
+    path = win_addslash(path)
   end
   cb("oil://" .. path)
 end
 
---TODO: is this ok?
+---@param err oil.ParseError
+---@return boolean
+M.filter_error = function(err)
+  if err.message == "Duplicate filename" then
+    return false
+  end
+  return true
+end
+
 ---@param action oil.Action
 ---@return string
 M.render_action = function(action)
   if action.type == "delete" then
     local entry = assert(cache.get_entry_by_url(action.url))
     local meta = entry[FIELD_META]
-    ---@type oil.TrashInfo
+    ---@type oil.WindowsTrashInfo
     local trash_info = meta.trash_info
     local short_path = fs.shorten_path(trash_info.original_path)
     return string.format(" PURGE %s", short_path)
@@ -228,37 +326,41 @@ M.render_action = function(action)
   end
 end
 
+---@param path string
+---@param cb fun(err?: string, raw_entries: oil.WindowsRawEntry[]?)
+local purge = function(path, cb)
+  local jid = vim.fn.jobstart({
+    "powershell",
+    "-NoProfile",
+    "-ExecutionPolicy",
+    "Bypass",
+    "-Command",
+    ([[
+$path = Get-Item '%s'
+Remove-Item $path -Recurse -Confirm:$false
+]]):format(path:gsub("'", "''")),
+  }, {
+    on_exit = function(_, code)
+      if code ~= 0 then
+        return cb("Error purging file")
+      end
+      cb()
+    end,
+  })
+  if jid <= 0 then
+    cb("Could not purge item")
+  end
+end
+
 ---@param action oil.Action
 ---@param cb fun(err: nil|string)
 M.perform_action = function(action, cb)
-  if action.type == "create" then
-    -- TODO: do nothing?
-  elseif action.type == "delete" then
+  if action.type == "delete" then
     local entry = assert(cache.get_entry_by_url(action.url))
-    local meta = entry[FIELD_META] --[[@as {stat: uv_fs_t, trash_info: oil.TrashInfo, display_name: string}]]
+    local meta = entry[FIELD_META] --[[@as {stat: uv_fs_t, trash_info: oil.WindowsTrashInfo, display_name: string}]]
     local trash_info = meta.trash_info
 
-    local jid = vim.fn.jobstart({
-      "powershell",
-      "-NoProfile",
-      "-ExecutionPolicy",
-      "Bypass",
-      "-Command",
-      ([[
-$path = Get-Item '%s'
-Remove-Item $path -Recurse -Confirm:$false
-]]):format(trash_info.trash_file),
-    }, {
-      on_exit = function(_, code)
-        if code ~= 0 then
-          return cb("Error purging file")
-        end
-        cb()
-      end,
-    })
-    if jid <= 0 then
-      cb("Could not purge item")
-    end
+    purge(trash_info.trash_file, cb)
   elseif action.type == "move" then
     local src_adapter = assert(config.get_adapter_by_scheme(action.src_url))
     local dest_adapter = assert(config.get_adapter_by_scheme(action.dest_url))
@@ -270,7 +372,7 @@ Remove-Item $path -Recurse -Confirm:$false
       local _, dest_path = util.parse_url(action.dest_url)
       assert(dest_path)
       local entry = assert(cache.get_entry_by_url(action.src_url))
-      local meta = entry[FIELD_META] --[[@as {stat: uv_fs_t, trash_info: oil.TrashInfo, display_name: string}]]
+      local meta = entry[FIELD_META] --[[@as {stat: uv_fs_t, trash_info: oil.WindowsTrashInfo, display_name: string}]]
       local trash_info = meta.trash_info
 
       local jid = vim.fn.jobstart({
@@ -279,6 +381,7 @@ Remove-Item $path -Recurse -Confirm:$false
         "-ExecutionPolicy",
         "Bypass",
         "-Command",
+        -- 0xa is the constant for Recycle Bin. See https://learn.microsoft.com/en-us/windows/win32/api/shldisp/ne-shldisp-shellspecialfolderconstants
         ([[
 $path = Get-Item '%s'
 $shell = New-Object -ComObject 'Shell.Application'
@@ -316,12 +419,13 @@ M.delete_to_trash = function(path, cb)
     "-ExecutionPolicy",
     "Bypass",
     "-Command",
+    -- 0 is the constant for Windows Desktop. See https://learn.microsoft.com/en-us/windows/win32/api/shldisp/ne-shldisp-shellspecialfolderconstants
     ([[
 $path = Get-Item '%s'
 $shell = New-Object -ComObject 'Shell.Application'
 $folder = $shell.NameSpace(0)
 $folder.ParseName($path.FullName).InvokeVerb('delete')
-]]):format(path),
+]]):format(path:gsub("'", "''")),
   }, {
     stdout_buffered = true,
     on_exit = function(_, code)

--- a/lua/oil/adapters/trash/windows.lua
+++ b/lua/oil/adapters/trash/windows.lua
@@ -20,9 +20,9 @@ if vim.fn.has("nvim-0.10") == 1 then
 else
   powershell_date_grammar = {
     ---@param input string
-    ---@return integer
+    ---@return integer?
     match = function(self, input)
-      return input:match("/Date%((%d+)%)/")
+      return tonumber(input:match("/Date%((%d+)%)/"))
     end,
   }
 end

--- a/lua/oil/adapters/trash/windows.lua
+++ b/lua/oil/adapters/trash/windows.lua
@@ -112,6 +112,35 @@ M.is_modifiable = function(_bufnr)
   return true
 end
 
+-- TODO: do something similar?
+-- local file_columns = {}
+-- file_columns.mtime = {
+--   render = function(entry, conf)
+--     local meta = entry[FIELD_META]
+--     if not meta then
+--       return nil
+--     end
+--     ---@type oil.TrashInfo
+--     local trash_info = meta.trash_info
+--     local time = trash_info and trash_info.deletion_date or meta.stat and meta.stat.mtime.sec
+--     if not time then
+--       return nil
+--     end
+--     local fmt = conf and conf.format
+--     local ret
+--     if fmt then
+--       ret = vim.fn.strftime(fmt, time)
+--     else
+--       local year = vim.fn.strftime("%Y", time)
+--       if year ~= current_year then
+--         ret = vim.fn.strftime("%b %d %Y", time)
+--       else
+--         ret = vim.fn.strftime("%b %d %H:%M", time)
+--       end
+--     end
+--     return ret
+--   end,
+
 --TODO: is this ok?
 ---@param name string
 ---@return nil|oil.ColumnDefinition
@@ -136,7 +165,6 @@ M.normalize_url = function(url, callback)
   )
 end
 
---TODO: use cache
 ---@param url string
 ---@param entry oil.Entry
 ---@param cb fun(path: string)

--- a/lua/oil/adapters/trash/windows.lua
+++ b/lua/oil/adapters/trash/windows.lua
@@ -385,9 +385,9 @@ local function create_trash_info_and_copy(path, type, cb)
         return cb(err)
       end
       -- delete original file
-      M.delete_to_trash(path, function(err)
-        if err then
-          return cb(err)
+      M.delete_to_trash(path, function(err2)
+        if err2 then
+          return cb(err2)
         end
         -- rename temporary copy to the original file name
         fs.recursive_move(type, temp_path, path, cb)

--- a/lua/oil/adapters/trash/windows.lua
+++ b/lua/oil/adapters/trash/windows.lua
@@ -41,9 +41,8 @@ end
 ---@param column_defs string[]
 ---@param cb fun(err?: string, entries?: oil.InternalEntry[], fetch_more?: fun())
 M.list = function(url, column_defs, cb)
-  -- TODO: is this needed?
-  -- local _, path = util.parse_url(url)
-  -- assert(path)
+  local _, path = util.parse_url(url)
+  assert(path)
 
   ---@type string?
   local stdout

--- a/lua/oil/adapters/trash/windows.lua
+++ b/lua/oil/adapters/trash/windows.lua
@@ -17,4 +17,29 @@ local M = {}
 --   error("No trash found")
 -- end
 
+---@param path string
+---@param cb fun(err?: string)
+M.delete_to_trash = function(path, cb)
+  vim.system({
+    "powershell",
+    "-ExecutionPolicy",
+    "Bypass",
+    "-Command",
+    ([[
+$path = Get-Item '%s'
+$shell = New-Object -ComObject 'Shell.Application'
+$folder = $shell.NameSpace(0)
+$folder.ParseName($path.FullName).InvokeVerb('delete')
+]]):format(path),
+  }, {
+    text = false,
+  }, function(data)
+    if data.stderr and data.stderr ~= "" then
+      cb(data.stderr)
+    else
+      cb()
+    end
+  end)
+end
+
 return M

--- a/lua/oil/config.lua
+++ b/lua/oil/config.lua
@@ -1,5 +1,3 @@
-local uv = vim.uv or vim.loop
-
 local default_config = {
   -- Oil will take over directory buffers (e.g. `vim .` or `:e src/`)
   -- Set to false if you still want to use netrw.

--- a/lua/oil/config.lua
+++ b/lua/oil/config.lua
@@ -155,17 +155,6 @@ M.setup = function(opts)
     new_conf.keymaps = opts.keymaps or {}
   end
 
-  if new_conf.delete_to_trash then
-    local is_windows = uv.os_uname().version:match("Windows")
-    if is_windows then
-      vim.notify(
-        "oil.nvim: delete_to_trash is true, but trash is not yet supported on Windows.\nDeleted files will be permanently removed",
-        vim.log.levels.WARN
-      )
-      new_conf.delete_to_trash = false
-    end
-  end
-
   for k, v in pairs(new_conf) do
     M[k] = v
   end

--- a/lua/oil/fs.lua
+++ b/lua/oil/fs.lua
@@ -87,7 +87,7 @@ M.posix_to_os_path = function(path)
     if vim.startswith(path, "/") then
       local drive = path:match("^/(%a+)")
       local rem = path:sub(drive:len() + 2)
-      return string.format("%s:\\%s", drive, rem:gsub("/", "\\"))
+      return string.format("%s:%s", drive, rem:gsub("/", "\\"))
     else
       local newpath = path:gsub("/", "\\")
       return newpath

--- a/lua/oil/init.lua
+++ b/lua/oil/init.lua
@@ -421,7 +421,9 @@ end
 M.select = function(opts, callback)
   local cache = require("oil.cache")
   local config = require("oil.config")
+  local constants = require("oil.constants")
   local pathutil = require("oil.pathutil")
+  local FIELD_META = constants.FIELD_META
   opts = vim.tbl_extend("keep", opts or {}, {})
   local function finish(err)
     if err then
@@ -498,6 +500,13 @@ M.select = function(opts, callback)
       local is_new_entry = entry.id == nil
       local is_moved_from_dir = entry.id and cache.get_parent_url(entry.id) ~= bufname
       local is_renamed = entry.parsed_name ~= entry.name
+      local internal_entry = entry.id and cache.get_entry_by_id(entry.id)
+      if internal_entry then
+        local meta = internal_entry[FIELD_META]
+        if meta and meta.display_name then
+          is_renamed = entry.parsed_name ~= meta.display_name
+        end
+      end
       if is_new_entry or is_moved_from_dir or is_renamed then
         any_moved = true
         break


### PR DESCRIPTION
This only adds support for `delete_to_trash` to the Windows trash adapter. I'm not sure about how the other adapters (freedesktop and mac) work, but at a glance I think they allow restoring files from trash, browsing files from trash, etc. Am I correct? I would like to help with the Windows trash adapter as much as I can, but I'm a bit lost.

Thanks for the amazing pluging, by the way :3.