### PR TITLE
perf: only execute on current buffer since this event is called on each buffer

### DIFF
--- a/lua/oil/init.lua
+++ b/lua/oil/init.lua
@@ -1128,6 +1128,9 @@ M.setup = function(opts)
     group = aug,
     pattern = "*",
     callback = function(params)
+      if vim.g.SessionLoad ~= 1 then
+        return
+      end
       local util = require("oil.util")
       local scheme = util.parse_url(params.file)
       if config.adapters[scheme] and vim.api.nvim_buf_line_count(params.buf) == 1 then

--- a/lua/oil/init.lua
+++ b/lua/oil/init.lua
@@ -1129,12 +1129,9 @@ M.setup = function(opts)
     pattern = "*",
     callback = function(params)
       local util = require("oil.util")
-      for _, bufnr in ipairs(vim.api.nvim_list_bufs()) do
-        local bufname = vim.api.nvim_buf_get_name(bufnr)
-        local scheme = util.parse_url(bufname)
-        if config.adapters[scheme] and vim.api.nvim_buf_line_count(bufnr) == 1 then
-          load_oil_buffer(bufnr)
-        end
+      local scheme = util.parse_url(params.file)
+      if config.adapters[scheme] and vim.api.nvim_buf_line_count(params.buf) == 1 then
+        load_oil_buffer(params.buf)
       end
     end,
   })


### PR DESCRIPTION
When saving sessions, the file that you source (i.e. `Session.vim`) executes `doautoall SessionLoadPost` which will execute the autocmd event `SessionLoadPost` on each buffer. So we don't need to manually loop over each buffer ourselves, the autocmd execution actually handles it for us. This causes an exponential growth in the number of times these calculations are made.

Also I found this while investigating #245 but sadly this doesn't fix the problem root there.


EDIT: ~I just pushed another performance improvement to check if `oil` is already loaded by checking the filetype. When restoring a session with `source` like the original issue #29 the filetype is not set to `oil`, but when loading views with `loadview` which also calls `SessionLoadPost` the oil buffers are already loaded and therefore the filetype is already `oil`. This allows us to optimize this out. There might be a better way to check if oil is already loaded in a buffer, if so let me know! Another thing is that with this performance update it circumvents the problem in #245 so that it never happens, but doesn't fix the root issue which seems to be a bug in the `load_oil_buffer` function where even when it's only called on buffer numbers that belong to `oil` buffers, they sometimes clobber details in other buffer numbers which I believe is coming from the fact that those buffers do not actively belong to a window. This should still be investigated by someone more familiar with the codebase. Because this doesn't actually fix the bug in that function, it might not be considered "closing" of #245 even though the symptoms of the problem go away~

EDIT 2: Most up to date information on what this PR does and what it does not do can be found below: https://github.com/stevearc/oil.nvim/pull/246#issuecomment-1841370744

With the most recent changes we can also say this this resolves #245 since it _should_ avoid the issue from ever happening, but it might come up down the road if someone gets into some complicated edge cases when using `mksession`. Chances are this is never going to happen though.