### PR TITLE
fix: willRename source path

### DIFF
--- a/lua/oil/lsp_helpers.lua
+++ b/lua/oil/lsp_helpers.lua
@@ -51,7 +51,7 @@ end
 ---@return nil|{src: string, dest: string}
 local function get_matching_paths(client, path_pairs)
   local filters =
-      vim.tbl_get(client.server_capabilities, "workspace", "fileOperations", "willRename", "filters")
+    vim.tbl_get(client.server_capabilities, "workspace", "fileOperations", "willRename", "filters")
   if not filters then
     return nil
   end

--- a/lua/oil/lsp_helpers.lua
+++ b/lua/oil/lsp_helpers.lua
@@ -13,6 +13,16 @@ local function file_matches(filepath, pattern)
       return false
     end
   end
+
+  if vim.lsp._watchfiles then
+    local glob = pattern.glob
+    local path = filepath
+    if vim.tbl_get(pattern, "options", "ignoreCase") then
+      glob, path = glob:lower(), path:lower()
+    end
+    return vim.lsp._watchfiles._match(glob, path)
+  end
+
   local pat = vim.fn.glob2regpat(pattern.glob)
   if vim.tbl_get(pattern, "options", "ignoreCase") then
     pat = "\\c" .. pat
@@ -41,14 +51,17 @@ end
 ---@return nil|{src: string, dest: string}
 local function get_matching_paths(client, path_pairs)
   local filters =
-    vim.tbl_get(client.server_capabilities, "workspace", "fileOperations", "willRename", "filters")
+      vim.tbl_get(client.server_capabilities, "workspace", "fileOperations", "willRename", "filters")
   if not filters then
     return nil
   end
   local ret = {}
   for _, pair in ipairs(path_pairs) do
-    if fs.is_subpath(client.config.root_dir, pair.src) and any_match(pair.src, filters) then
-      table.insert(ret, pair)
+    if fs.is_subpath(client.config.root_dir, pair.src) then
+      local relative_file = pair.src:sub(client.config.root_dir:len() + 2)
+      if any_match(pair.src, filters) or any_match(relative_file, filters) then
+        table.insert(ret, pair)
+      end
     end
   end
   if vim.tbl_isempty(ret) then

--- a/lua/oil/lsp_helpers.lua
+++ b/lua/oil/lsp_helpers.lua
@@ -47,11 +47,8 @@ local function get_matching_paths(client, path_pairs)
   end
   local ret = {}
   for _, pair in ipairs(path_pairs) do
-    if fs.is_subpath(client.config.root_dir, pair.src) then
-      local relative_file = pair.src:sub(client.config.root_dir:len() + 2)
-      if any_match(relative_file, filters) then
-        table.insert(ret, pair)
-      end
+    if fs.is_subpath(client.config.root_dir, pair.src) and any_match(pair.src, filters) then
+      table.insert(ret, pair)
     end
   end
   if vim.tbl_isempty(ret) then


### PR DESCRIPTION
Closes #247.
I think getting the relative path is unnecessary because the glob pattern will always match the full path, and it can mess up with some server filters, for example: tsserver uses `**/*.js` but the relative path omit the parent dir.