### PR TITLE
Feature: Implement actions for sending oil entries to quickfix #223

### DIFF
--- a/lua/oil/actions.lua
+++ b/lua/oil/actions.lua
@@ -337,6 +337,55 @@ M.toggle_trash = {
   end,
 }
 
+M.send_to_qflist = {
+  desc = "Sends files in the current oil directory to the quickfix list, replacing the previous entries.",
+  callback = function()
+    util.send_to_quickfix({
+      directories = false,
+      files = true,
+      target = "qf",
+      mode = " ",
+    })
+  end,
+}
+
+M.add_to_qflist = {
+  desc = "Adds files in the current oil directory to the quickfix list, keeping the previous entries.",
+  callback = function()
+    util.send_to_quickfix({
+      directories = false,
+      files = true,
+      target = "qf",
+      mode = "a",
+    })
+  end,
+}
+
+M.send_to_loclist = {
+  desc = "Sends files in the current oil directory to the location list, replacing the previous entries.",
+  callback = function()
+    util.send_to_quickfix({
+      directories = false,
+      files = true,
+      target = "loclist",
+      mode = " ",
+    })
+  end,
+}
+
+M.add_to_loclist = {
+  desc = "Adds files in the current oil directory to the location list, keeping the previous entries.",
+  callback = function()
+    util.send_to_quickfix({
+      directories = false,
+      files = true,
+      target = "loclist",
+      mode = "a",
+    })
+  end,
+}
+
+
 ---List actions for documentation generation
 ---@private
 M._get_actions = function()


### PR DESCRIPTION
Closes #223 .

Exposes actions:
 - `actions.send_to_qflist`: Sends files from current oil dir to quickfix and replaces old entries
 - `actions.add_to_qflist`: Sends files from current oil dir to quickfix and keeps old entries
 - `actions.send_to_loclist`: Sends files from current oil dir to location list and replaces old entries
 - `actions.add_to_loclist`: Sends files from current oil dir to location list and keeps old entries
 
 The quickfix actions trigger `QuickFixCmdPre` and `QuickFixCmdPost` autocommands.
 
 The actions do not open the quickfix window, since you may create an autocmd to open it automatically on `QuickFixCmdPost`.