### PR TITLE
feat: add 'update_on_cursor_moved' option to preview window

### DIFF
--- a/doc/oil.txt
+++ b/doc/oil.txt
@@ -134,6 +134,8 @@ OPTIONS                                                              *oil-option
         win_options = {
           winblend = 0,
         },
+        -- Whether the preview window is automatically updated when the cursor is moved
+        update_on_cursor_moved = true,
       },
       -- Configuration for the floating progress window
       progress = {

--- a/lua/oil/config.lua
+++ b/lua/oil/config.lua
@@ -120,6 +120,8 @@ local default_config = {
     win_options = {
       winblend = 0,
     },
+    -- Whether the preview window is automatically updated when the cursor is moved
+    update_on_cursor_moved = true,
   },
   -- Configuration for the floating progress window
   progress = {

--- a/lua/oil/view.lua
+++ b/lua/oil/view.lua
@@ -364,34 +364,36 @@ M.initialize = function(bufnr)
         end
       end
 
-      -- Debounce and update the preview window
-      if timer then
-        timer:again()
-        return
-      end
-      timer = vim.loop.new_timer()
-      if not timer then
-        return
-      end
-      timer:start(10, 100, function()
-        timer:stop()
-        timer:close()
-        timer = nil
-        vim.schedule(function()
-          if vim.api.nvim_get_current_buf() ~= bufnr then
-            return
-          end
-          local entry = oil.get_cursor_entry()
-          if entry then
-            local winid = util.get_preview_win()
-            if winid then
-              if entry.id ~= vim.w[winid].oil_entry_id then
-                oil.select({ preview = true })
+      if config.preview.update_on_cursor_moved then
+        -- Debounce and update the preview window
+        if timer then
+          timer:again()
+          return
+        end
+        timer = vim.loop.new_timer()
+        if not timer then
+          return
+        end
+        timer:start(10, 100, function()
+          timer:stop()
+          timer:close()
+          timer = nil
+          vim.schedule(function()
+            if vim.api.nvim_get_current_buf() ~= bufnr then
+              return
+            end
+            local entry = oil.get_cursor_entry()
+            if entry then
+              local winid = util.get_preview_win()
+              if winid then
+                if entry.id ~= vim.w[winid].oil_entry_id then
+                  oil.select({ preview = true })
+                end
               end
             end
-          end
+          end)
         end)
-      end)
+      end
     end,
   })
 


### PR DESCRIPTION
By default, the preview window is updated when the cursor is moved, but this behavior makes it heavy and sometimes stuck when opening large files.
So I added an option to make it behave like netrw's p key, which does not automatically synchronize.

I thought it would be good to allow users to choose which behavior they prefer.