### PR TITLE
feat: normal_uneditable configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,8 @@ require("oil").setup({
     -- "size",
     -- "mtime",
   },
+  -- Prevent these columns from being edited
+  normal_uneditable = { },
   -- Buffer-local options to use for oil buffers
   buf_options = {
     buflisted = false,

--- a/lua/oil/config.lua
+++ b/lua/oil/config.lua
@@ -1,4 +1,3 @@
-local uv = vim.uv or vim.loop
 
 local default_config = {
   -- Oil will take over directory buffers (e.g. `vim .` or `:e src/`)
@@ -12,6 +11,8 @@ local default_config = {
     -- "size",
     -- "mtime",
   },
+  -- Prevent these columns from being edited in normal mode (cursor cannot move to them)
+  normal_uneditable = { },
   -- Buffer-local options to use for oil buffers
   buf_options = {
     buflisted = false,

--- a/lua/oil/view.lua
+++ b/lua/oil/view.lua
@@ -225,7 +225,9 @@ local function get_first_mutable_column_col(adapter, ranges)
   for col_name, start_len in pairs(ranges) do
     local start = start_len[1]
     local col_spec = columns.get_column(adapter, col_name)
-    local is_col_mutable = col_spec and col_spec.perform_action ~= nil
+    local is_col_mutable = col_spec
+        and col_spec.perform_action ~= nil
+        and not vim.tbl_contains(config.normal_uneditable, col_name)
     if is_col_mutable and start < min_col then
       min_col = start
     end


### PR DESCRIPTION
closes #257

This is the easiest way that I could make this change. It's not all that pretty, but it works. 

I'm open to ideas about this config variable name. Originally I called it `force_uneditable` but you can edit the value in insert mode still, so I changed it to `normal_uneditable`. That name is not great, but I can't think of a better one at the moment.
