### PR TITLE
perf(trash_windows): use a single powershell instance for operations

### DIFF
--- a/lua/oil/adapters/trash/windows.lua
+++ b/lua/oil/adapters/trash/windows.lua
@@ -42,23 +42,84 @@ end
 ---@field Path string
 ---@field OriginalPath string
 
----@param cb fun(err?: string, raw_entries: oil.WindowsRawEntry[]?)
-local get_raw_entries = function(cb)
-  ---@type string?
-  local stdout
+---@type integer?
+local get_entries_jid
+---@type string[]
+local stdout = {}
+local is_reading_data = true
+---@type fun(err?: string, raw_entries: oil.WindowsRawEntry[]?)?
+local get_entries_last_cb
 
+---@param cb fun(err?: string, raw_entries: oil.WindowsRawEntry[]?)
+---@return integer? jid
+local get_entries_start_powershell = function(cb)
   local jid = vim.fn.jobstart({
     "powershell",
     "-NoProfile",
+    "-NoLogo",
     "-ExecutionPolicy",
     "Bypass",
+    "-NoExit",
     "-Command",
-    -- The first line configures Windows Powershell to use UTF-8 for input and output
-    -- 0xa is the constant for Recycle Bin. See https://learn.microsoft.com/en-us/windows/win32/api/shldisp/ne-shldisp-shellspecialfolderconstants
+    "-",
+  }, {
+    ---@param data string[]
+    on_stdout = function(_, data)
+      if not get_entries_last_cb then
+        return
+      end
+      for _, fragment in ipairs(data) do
+        if fragment == "__END__" then
+          local cb2 = get_entries_last_cb
+          get_entries_last_cb = nil
+          is_reading_data = false
+          local json = table.concat(stdout, "")
+          if json == "" then
+            json = "[]"
+          end
+          local ok, raw_entries = pcall(vim.json.decode, json)
+          if not ok then
+            cb2("error")
+            return
+          end
+          stdout = {}
+          cb2(nil, raw_entries)
+        elseif is_reading_data then
+          table.insert(stdout, fragment)
+        end
+      end
+    end,
+  })
+  if jid <= 0 then
+    cb("Could not list windows devices")
+    return
+  end
+  -- The first line configures Windows Powershell to use UTF-8 for input and output
+  -- 0xa is the constant for Recycle Bin. See https://learn.microsoft.com/en-us/windows/win32/api/shldisp/ne-shldisp-shellspecialfolderconstants
+  vim.api.nvim_chan_send(
+    jid,
     [[
 $OutputEncoding = [Console]::InputEncoding = [Console]::OutputEncoding = New-Object System.Text.UTF8Encoding
 $shell = New-Object -ComObject 'Shell.Application'
 $folder = $shell.NameSpace(0xa)
+]]
+  )
+  return jid
+end
+
+---@param cb fun(err?: string, raw_entries: oil.WindowsRawEntry[]?)
+local get_raw_entries = function(cb)
+  if not get_entries_jid then
+    get_entries_jid = assert(get_entries_start_powershell(cb))
+  end
+  if get_entries_last_cb then
+    get_entries_last_cb("Cancelled")
+  end
+  get_entries_last_cb = cb
+  is_reading_data = true
+  vim.api.nvim_chan_send(
+    get_entries_jid,
+    [[
 $data = @(foreach ($i in $folder.items())
     {
         @{
@@ -69,25 +130,11 @@ $data = @(foreach ($i in $folder.items())
             OriginalPath=-join($i.ExtendedProperty('DeletedFrom'), "\", $i.Name)
         }
     })
-ConvertTo-Json $data
-]],
-  }, {
-    stdout_buffered = true,
-    on_stdout = function(_, data)
-      stdout = table.concat(data, "\n")
-    end,
-    on_exit = function(_, code)
-      if code ~= 0 then
-        return cb("Error listing files on trash")
-      end
-      assert(stdout)
-      local raw_entries = vim.json.decode(stdout)
-      cb(nil, raw_entries)
-    end,
-  })
-  if jid <= 0 then
-    cb("Could not list windows devices")
-  end
+ConvertTo-Json $data -Compress
+Write-Host '__END__'
+
+]]
+  )
 end
 
 ---@class oil.WindowsTrashInfo
@@ -454,34 +501,69 @@ end
 
 M.supported_cross_adapter_actions = { files = "move" }
 
----@param path string
----@param cb fun(err?: string)
-M.delete_to_trash = function(path, cb)
+---@type integer?
+local delete_to_trash_jid
+---@type fun(err?: string, raw_entries: oil.WindowsRawEntry[]?)?
+local delete_to_trash_last_cb
+
+---@param cb fun(err?: string, raw_entries: oil.WindowsRawEntry[]?)
+---@return integer? jid
+local delete_to_trash_start_powershell = function(cb)
   local jid = vim.fn.jobstart({
     "powershell",
     "-NoProfile",
+    "-NoLogo",
     "-ExecutionPolicy",
     "Bypass",
+    "-NoExit",
     "-Command",
-    -- 0 is the constant for Windows Desktop. See https://learn.microsoft.com/en-us/windows/win32/api/shldisp/ne-shldisp-shellspecialfolderconstants
-    ([[
-$path = Get-Item '%s'
-$shell = New-Object -ComObject 'Shell.Application'
-$folder = $shell.NameSpace(0)
-$folder.ParseName($path.FullName).InvokeVerb('delete')
-]]):format(path:gsub("'", "''")),
+    "-",
   }, {
-    stdout_buffered = true,
-    on_exit = function(_, code)
-      if code ~= 0 then
-        return cb("Error sendig file to trash")
+    on_stdout = function(_, data)
+      if not delete_to_trash_last_cb then
+        return
       end
-      cb()
+      for _, fragment in ipairs(data) do
+        if fragment == "__END__" then
+          delete_to_trash_last_cb()
+          delete_to_trash_last_cb = nil
+        end
+      end
     end,
   })
   if jid <= 0 then
     cb("Could not list windows devices")
+    return
   end
+  -- 0 is the constant for Windows Desktop. See https://learn.microsoft.com/en-us/windows/win32/api/shldisp/ne-shldisp-shellspecialfolderconstants
+  vim.api.nvim_chan_send(
+    jid,
+    [[
+$shell = New-Object -ComObject 'Shell.Application'
+$folder = $shell.NameSpace(0)
+]]
+  )
+  return jid
+end
+
+---@param path string
+---@param cb fun(err?: string)
+M.delete_to_trash = function(path, cb)
+  if not delete_to_trash_jid then
+    delete_to_trash_jid = assert(delete_to_trash_start_powershell(cb))
+  end
+  if delete_to_trash_last_cb then
+    delete_to_trash_last_cb()
+  end
+  delete_to_trash_last_cb = cb
+  vim.api.nvim_chan_send(
+    delete_to_trash_jid,
+    ([[
+$path = Get-Item '%s'
+$folder.ParseName($path.FullName).InvokeVerb('delete')
+Write-Host '__END__'
+]]):format(path:gsub("'", "''"))
+  )
 end
 
 return M

--- a/lua/oil/adapters/trash/windows.lua
+++ b/lua/oil/adapters/trash/windows.lua
@@ -47,7 +47,7 @@ end
 local get_entries_powershell
 
 ---@param cb fun(err?: string, raw_entries: oil.WindowsRawEntry[]?)
-local _get_entries = function(cb)
+local run_get_entries_command = function(cb)
   get_entries_powershell:run(
     [[
 $data = @(foreach ($i in $folder.items())
@@ -95,11 +95,11 @@ $folder = $shell.NameSpace(0xa)
           cb(err)
           return
         end
-        _get_entries(cb)
+        run_get_entries_command(cb)
       end
     )
   else
-    _get_entries(cb)
+    run_get_entries_command(cb)
   end
 end
 
@@ -472,7 +472,7 @@ local delete_to_trash_powershell
 
 ---@param path string
 ---@param cb fun(err?: string)
-local function _delete_to_trash(path, cb)
+local function run_delete_to_trash_command(path, cb)
   delete_to_trash_powershell:run(
     ([[
 $path = Get-Item '%s'
@@ -500,11 +500,11 @@ $folder = $shell.NameSpace(0)
           cb(err)
           return
         end
-        _delete_to_trash(path, cb)
+        run_delete_to_trash_command(path, cb)
       end
     )
   else
-    _delete_to_trash(path, cb)
+    run_delete_to_trash_command(path, cb)
   end
 end
 

--- a/lua/oil/adapters/trash/windows/powershell-connection.lua
+++ b/lua/oil/adapters/trash/windows/powershell-connection.lua
@@ -18,7 +18,7 @@ function PowershellConnection.new()
     is_reading_data = false,
   }, { __index = PowershellConnection })
 
-  self.jid = vim.fn.jobstart({
+  local jid = vim.fn.jobstart({
     "powershell",
     "-NoProfile",
     "-NoLogo",
@@ -43,12 +43,21 @@ function PowershellConnection.new()
             cb(success .. ": " .. output, output)
           end
           self.stdout = {}
+          self:_consume()
         elseif self.is_reading_data then
           table.insert(self.stdout, fragment)
         end
       end
     end,
   })
+
+  if jid == 0 then
+    self:_set_connection_error("passed invalid arguments to 'powershell'")
+  elseif jid == -1 then
+    self:_set_connection_error("'powershell' is not executable")
+  else
+    self.jid = jid
+  end
 
   return self
 end

--- a/lua/oil/adapters/trash/windows/powershell-connection.lua
+++ b/lua/oil/adapters/trash/windows/powershell-connection.lua
@@ -1,0 +1,91 @@
+---@class (exact) oil.PowershellCommand
+---@field cmd string
+---@field cb fun(err?: string, output?: string)
+---@field running? boolean
+
+---@class oil.PowershellConnection
+---@field private jid integer
+---@field commands oil.PowershellCommand[]
+---@field stdout string[]
+---@field is_reading_data boolean
+local PowershellConnection = {}
+
+---@return oil.PowershellConnection
+function PowershellConnection.new()
+  local self = setmetatable({
+    commands = {},
+    stdout = {},
+    is_reading_data = false,
+  }, { __index = PowershellConnection })
+
+  self.jid = vim.fn.jobstart({
+    "powershell",
+    "-NoProfile",
+    "-NoLogo",
+    "-ExecutionPolicy",
+    "Bypass",
+    "-NoExit",
+    "-Command",
+    "-",
+  }, {
+    ---@param data string[]
+    on_stdout = function(_, data)
+      for _, fragment in ipairs(data) do
+        if fragment:find("===DONE%((%a+)%)===") then
+          self.is_reading_data = false
+          local output = table.concat(self.stdout, "")
+          local cb = self.commands[1].cb
+          table.remove(self.commands, 1)
+          local success = fragment:match("===DONE%((%a+)%)===")
+          if success == "True" then
+            cb(nil, output)
+          elseif success == "False" then
+            cb(success .. ": " .. output, output)
+          end
+          self.stdout = {}
+        elseif self.is_reading_data then
+          table.insert(self.stdout, fragment)
+        end
+      end
+    end,
+  })
+
+  return self
+end
+
+---@param command string
+---@param cb fun(err?: string, output?: string[])
+function PowershellConnection:run(command, cb)
+  if self.connection_error then
+    cb(self.connection_error)
+  else
+    table.insert(self.commands, { cmd = command, cb = cb })
+    self:_consume()
+  end
+end
+
+function PowershellConnection:_consume()
+  if not vim.tbl_isempty(self.commands) then
+    local cmd = self.commands[1]
+    if not cmd.running then
+      cmd.running = true
+      self.is_reading_data = true
+      vim.api.nvim_chan_send(self.jid, cmd.cmd .. '\nWrite-Host "===DONE($?)==="\n')
+    end
+  end
+end
+
+---@param err string
+function PowershellConnection:_set_connection_error(err)
+  if self.connection_error then
+    return
+  end
+  self.connection_error = err
+  local commands = self.commands
+  self.commands = {}
+  for _, cmd in ipairs(commands) do
+    cmd.cb(err)
+  end
+end
+
+return PowershellConnection

--- a/lua/oil/adapters/trash/windows/powershell-trash.lua
+++ b/lua/oil/adapters/trash/windows/powershell-trash.lua
@@ -1,0 +1,80 @@
+-- A wrapper around trash operations using windows powershell
+local Powershell = require("oil.adapters.trash.windows.powershell-connection")
+
+---@class oil.WindowsRawEntry
+---@field IsFolder boolean
+---@field DeletionDate integer
+---@field Name string
+---@field Path string
+---@field OriginalPath string
+
+local M = {}
+
+-- The first line configures Windows Powershell to use UTF-8 for input and output
+-- 0xa is the constant for Recycle Bin. See https://learn.microsoft.com/en-us/windows/win32/api/shldisp/ne-shldisp-shellspecialfolderconstants
+local list_entries_init = [[
+$OutputEncoding = [Console]::InputEncoding = [Console]::OutputEncoding = New-Object System.Text.UTF8Encoding
+$shell = New-Object -ComObject 'Shell.Application'
+$folder = $shell.NameSpace(0xa)
+]]
+
+local list_entries_cmd = [[
+$data = @(foreach ($i in $folder.items())
+    {
+        @{
+            IsFolder=$i.IsFolder;
+            DeletionDate=([DateTimeOffset]$i.extendedproperty('datedeleted')).ToUnixTimeSeconds();
+            Name=$i.Name;
+            Path=$i.Path;
+            OriginalPath=-join($i.ExtendedProperty('DeletedFrom'), "\", $i.Name)
+        }
+    })
+ConvertTo-Json $data -Compress
+]]
+
+---@type nil|oil.PowershellConnection
+local list_entries_powershell
+
+---@param cb fun(err?: string, raw_entries: oil.WindowsRawEntry[]?)
+M.list_raw_entries = function(cb)
+  if not list_entries_powershell then
+    list_entries_powershell = Powershell.new(list_entries_init)
+  end
+  list_entries_powershell:run(list_entries_cmd, function(err, string)
+    if err then
+      cb(err)
+      return
+    end
+
+    local ok, value = pcall(vim.json.decode, string)
+    if not ok then
+      cb(value)
+      return
+    end
+    cb(nil, value)
+  end)
+end
+
+-- 0 is the constant for Windows Desktop. See https://learn.microsoft.com/en-us/windows/win32/api/shldisp/ne-shldisp-shellspecialfolderconstants
+local delete_init = [[
+$shell = New-Object -ComObject 'Shell.Application'
+$folder = $shell.NameSpace(0)
+]]
+local delete_cmd = [[
+$path = Get-Item '%s'
+$folder.ParseName($path.FullName).InvokeVerb('delete')
+]]
+
+---@type nil|oil.PowershellConnection
+local delete_to_trash_powershell
+
+---@param path string
+---@param cb fun(err?: string)
+M.delete_to_trash = function(path, cb)
+  if not delete_to_trash_powershell then
+    delete_to_trash_powershell = Powershell.new(delete_init)
+  end
+  delete_to_trash_powershell:run((delete_cmd):format(path:gsub("'", "''")), cb)
+end
+
+return M


### PR DESCRIPTION
As mentioned in #243, trash support on windows is slow for some operations because it spawns a powershell process for every operation (sending 10 files to trash would spawn 10 powershell instances).

This PR starts two powershell intances (one for listing and one for deleting) and communicates with them over stdio (sending 10 files to trash now spawns only 1 powershell instance).

This improves the performance of trash related operations in windows after the first operation (because it's neccesary to start the powershell instance the first time). Maybe it could be preffered to start the powershell instances on startup instead (?).