### PR TITLE
Add border config for SSH and keymaps help window

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,10 @@ require("oil").setup({
     ["g."] = "actions.toggle_hidden",
     ["g\\"] = "actions.toggle_trash",
   },
+  -- Configuration for the floating keymaps help window
+  keymaps_help = {
+    border = "rounded",
+  },
   -- Set to false to disable all of the above keymaps
   use_default_keymaps = true,
   view_options = {

--- a/README.md
+++ b/README.md
@@ -268,6 +268,10 @@ require("oil").setup({
       winblend = 0,
     },
   },
+  -- Configuration for the floating SSH window
+  ssh = {
+    border = "rounded",
+  },
 })
 ```
 

--- a/doc/oil.txt
+++ b/doc/oil.txt
@@ -84,6 +84,10 @@ CONFIG                                                                *oil-confi
         ["g."] = "actions.toggle_hidden",
         ["g\\"] = "actions.toggle_trash",
       },
+      -- Configuration for the floating keymaps help window
+      keymaps_help = {
+        border = "rounded",
+      },
       -- Set to false to disable all of the above keymaps
       use_default_keymaps = true,
       view_options = {

--- a/doc/oil.txt
+++ b/doc/oil.txt
@@ -159,6 +159,10 @@ CONFIG                                                                *oil-confi
           winblend = 0,
         },
       },
+      -- Configuration for the floating SSH window
+      ssh = {
+        border = "rounded",
+      },
     })
 <
 

--- a/lua/oil/adapters/ssh/connection.lua
+++ b/lua/oil/adapters/ssh/connection.lua
@@ -1,3 +1,4 @@
+local config = require("oil.config")
 local layout = require("oil.layout")
 local util = require("oil.util")
 
@@ -277,7 +278,7 @@ function SSHConnection:open_terminal()
     row = row,
     col = col,
     style = "minimal",
-    border = "rounded",
+    border = config.ssh.border,
   })
   vim.cmd.startinsert()
 end

--- a/lua/oil/config.lua
+++ b/lua/oil/config.lua
@@ -67,6 +67,10 @@ local default_config = {
     ["g."] = "actions.toggle_hidden",
     ["g\\"] = "actions.toggle_trash",
   },
+  -- Configuration for the floating keymaps help window
+  keymaps_help = {
+    border = "rounded",
+  },
   -- Set to false to disable all of the above keymaps
   use_default_keymaps = true,
   view_options = {

--- a/lua/oil/config.lua
+++ b/lua/oil/config.lua
@@ -142,6 +142,10 @@ local default_config = {
       winblend = 0,
     },
   },
+  -- Configuration for the floating SSH window
+  ssh = {
+    border = "rounded",
+  },
 }
 
 -- The adapter API hasn't really stabilized yet. We're not ready to advertise or encourage people to

--- a/lua/oil/keymap_util.lua
+++ b/lua/oil/keymap_util.lua
@@ -1,4 +1,5 @@
 local actions = require("oil.actions")
+local config = require("oil.config")
 local layout = require("oil.layout")
 local util = require("oil.util")
 local M = {}
@@ -111,7 +112,7 @@ M.show_help = function(keymaps)
     height = math.min(editor_height, #lines),
     zindex = 150,
     style = "minimal",
-    border = "rounded",
+    border = config.keymaps_help.border,
   })
   local function close()
     if vim.api.nvim_win_is_valid(winid) then


### PR DESCRIPTION
Hi there,

First of all, thanks for Oil.nvim, awesome work!

Call me crazy, but one thing I really like, is to have control over how every window border looks within Neovim. Especially for consistency. I dislike it when one window has rounded borders and another one has double borders, etc.

Oil.nvim provides config options for almost every window, but not all of them. I forked this repo to allow configuring the border of the SSH window and the keymaps help window. If you like, you can merge it into master.

This gives us a total of 5 different borders we can configure, which raises the question if we might need a single configuration for all windows. Maybe a window config with overrides per window type, for those who want fine grained control? Something like this:

```lua
{
    window_style = {
         -- Defaults
         border = "rounded",
         padding = 2,
         -- Overrides
         progress_window = {
              border = "single",
              padding = 4,
         },
         -- etc, etc...
    },
}
```

I'd be willing to work on something like that. Let me know what you think.