### PR TITLE
Added ability to move files into folders (and create if they don't exist)

### DIFF
--- a/lua/oil/mutator/init.lua
+++ b/lua/oil/mutator/init.lua
@@ -76,21 +76,21 @@ M.create_actions_from_diffs = function(all_diffs)
     local parent_url = vim.api.nvim_buf_get_name(bufnr)
     for _, diff in ipairs(diffs) do
       if diff.type == "new" then
-        if diff.id then
-          local by_id = diff_by_id[diff.id]
-          ---HACK: set the destination on this diff for use later
-          ---@diagnostic disable-next-line: inject-field
-          diff.dest = parent_url .. diff.name
-          table.insert(by_id, diff)
-        else
-          -- Parse nested files like foo/bar/baz
-          local pieces = vim.split(diff.name, "/")
-          local url = parent_url:gsub("/$", "")
-          for i, v in ipairs(pieces) do
-            local is_last = i == #pieces
-            local entry_type = is_last and diff.entry_type or "directory"
-            local alternation = v:match("{([^}]+)}")
-            if is_last and alternation then
+        -- Parse nested files like foo/bar/baz
+        local pieces = vim.split(diff.name, "/")
+        local url = parent_url:gsub("/$", "")
+        for i, v in ipairs(pieces) do
+          local is_last = i == #pieces
+          local entry_type = is_last and diff.entry_type or "directory"
+          local alternation = v:match("{([^}]+)}")
+          if is_last then
+            if diff.id then
+              local by_id = diff_by_id[diff.id]
+              ---HACK: set the destination on this diff for use later
+              ---@diagnostic disable-next-line: inject-field
+              diff.dest = parent_url .. diff.name
+              table.insert(by_id, diff)
+            elseif alternation then
               -- Parse alternations like foo.{js,test.js}
               for _, alt in ipairs(vim.split(alternation, ",")) do
                 local alt_url = url .. "/" .. v:gsub("{[^}]+}", alt)
@@ -101,16 +101,21 @@ M.create_actions_from_diffs = function(all_diffs)
                   link = diff.link,
                 })
               end
-            else
-              url = url .. "/" .. v
-              add_action({
-                type = "create",
-                url = url,
-                entry_type = entry_type,
-                link = diff.link,
-              })
             end
+          else
+            -- TODO: Add to not create if already exists
+            if v == "." or v == ".." then
+              goto continue
+            end
+            url = url .. "/" .. v
+            add_action({
+              type = "create",
+              url = url,
+              entry_type = entry_type,
+              link = diff.link,
+            })
           end
+          ::continue::
         end
       elseif diff.type == "change" then
         add_action({
@@ -304,7 +309,7 @@ M.enforce_action_order = function(actions)
         -- We've detected a move cycle (e.g. MOVE /a -> /b + MOVE /b -> /a)
         -- Split one of the moves and retry
         local intermediate_url =
-          string.format("%s__oil_tmp_%05d", loop_action.src_url, math.random(999999))
+            string.format("%s__oil_tmp_%05d", loop_action.src_url, math.random(999999))
         local move_1 = {
           type = "move",
           entry_type = loop_action.entry_type,

--- a/lua/oil/mutator/init.lua
+++ b/lua/oil/mutator/init.lua
@@ -101,6 +101,14 @@ M.create_actions_from_diffs = function(all_diffs)
                   link = diff.link,
                 })
               end
+            else
+              url = url .. "/" .. v
+              add_action({
+                type = "create",
+                url = url,
+                entry_type = entry_type,
+                link = diff.link,
+              })
             end
           else
             -- TODO: Add to not create if already exists

--- a/lua/oil/mutator/parser.lua
+++ b/lua/oil/mutator/parser.lua
@@ -210,14 +210,12 @@ M.parse = function(bufnr)
       end
       local parsed_entry = result.data
       local entry = result.entry
-      if not parsed_entry.name or parsed_entry.name:match("/") or not entry then
+      if not parsed_entry.name or not entry then
         local message
         if not parsed_entry.name then
           message = "No filename found"
         elseif not entry then
           message = "Could not find existing entry (was the ID changed?)"
-        else
-          message = "Filename cannot contain '/'"
         end
         table.insert(errors, {
           message = message,

--- a/tests/parser_spec.lua
+++ b/tests/parser_spec.lua
@@ -170,6 +170,28 @@ describe("parser", function()
     }, errors)
   end)
 
+  it("errors on duplicate names for nested files", function()
+    local file = test_adapter.test_set("/foo/a.txt", "file")
+    local _ = test_adapter.test_set("/foo/bar", "directory")
+    local file2 = test_adapter.test_set("/foo/bar/a.txt", "file")
+    vim.cmd.edit({ args = { "oil-test:///foo/" } })
+    local bufnr = vim.api.nvim_get_current_buf()
+    set_lines(bufnr, {
+      "bar/",
+      string.format("/%d a.txt", file[FIELD_ID]),
+      string.format("/%d a.txt", file2[FIELD_ID]),
+    })
+    local _, errors = parser.parse(bufnr)
+    assert.are.same({
+      {
+        message = "Duplicate filename",
+        lnum = 2,
+        end_lnum = 3,
+        col = 0,
+      },
+    }, errors)
+  end)
+
   it("ignores new dirs with empty name", function()
     vim.cmd.edit({ args = { "oil-test:///foo/" } })
     local bufnr = vim.api.nvim_get_current_buf()


### PR DESCRIPTION
This solves feature request #117 without major changes to code.

Added functionality:
- Move an object into a folder
- Creates a new folder if it does not exist before

Known issues:
- Moving a file into an existing directory still shows as a CREATE action. (Purely visual, no data is overwritten.)
- Global path shown in preview is not simplified yet (i.e. `/home/user/oil/data/../test/test.lua` vs `/home/user/oil/test/test.lua`)

Example usage:
`<--` = parent directory of oil buffer
File directory structure:
```
- a/ <--
  - b.x
  - c.y
```
After changing `b.x` to `d1/d2/b.x`:
```
- a/ <--
  - d1/
  | - d2/
  | | - b.x
  - c.y
```
After changing `c.y` to `d1/c.y`:
```
- a/ <--
  - d1/
  | - d2/
  | | - b.x
  | - c.y
```
After changing 'c.y' to `../c.y`:
```
- a/ 
  - d1/ <--
  | - d2/
  | | - b.x
  - c.y
```

EDITS: Added examples and known issues