### PR TITLE
feat: add header line showing the current directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,8 @@ require("oil").setup({
   -- Set to false to disable all of the above keymaps
   use_default_keymaps = true,
   view_options = {
+    -- Show header line with the name of the current directory
+    show_header_line = false,
     -- Show files and directories that start with "."
     show_hidden = false,
     -- This function defines what is considered a "hidden" file

--- a/lua/oil/config.lua
+++ b/lua/oil/config.lua
@@ -70,6 +70,8 @@ local default_config = {
   -- Set to false to disable all of the above keymaps
   use_default_keymaps = true,
   view_options = {
+    -- Show header line with the current directory
+    show_header_line = false,
     -- Show files and directories that start with "."
     show_hidden = false,
     -- This function defines what is considered a "hidden" file

--- a/lua/oil/mutator/parser.lua
+++ b/lua/oil/mutator/parser.lua
@@ -166,7 +166,13 @@ M.parse = function(bufnr)
     return diffs, errors
   end
 
-  local lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, true)
+
+  local idx = 0
+  if config.view_options.show_header_line then
+    -- Start with index 1 instead of 0 to skip header line with the name of the current directory
+    idx = 1
+  end
+  local lines = vim.api.nvim_buf_get_lines(bufnr, idx, -1, true)
   local scheme, path = util.parse_url(bufname)
   local column_defs = columns.get_supported_columns(adapter)
   local parent_url = scheme .. path

--- a/lua/oil/view.lua
+++ b/lua/oil/view.lua
@@ -7,6 +7,7 @@ local fs = require("oil.fs")
 local keymap_util = require("oil.keymap_util")
 local loading = require("oil.loading")
 local util = require("oil.util")
+local init = require("oil.init")
 local M = {}
 
 local FIELD_ID = constants.FIELD_ID
@@ -555,6 +556,10 @@ local function render_buffer(bufnr, opts)
     col_width[i + 1] = 1
   end
 
+  if config.view_options.show_header_line then
+    -- add header line that shows the name of the current directory
+    table.insert(line_table, { init.get_current_dir() })
+  end
   if M.should_display("..", bufnr) then
     local cols = M.format_entry_cols({ 0, "..", "directory" }, column_defs, col_width, adapter)
     table.insert(line_table, cols)


### PR DESCRIPTION
* feat: add a header line showing the current directory. can be configured with with view_options.show_header_line. default is false.