### PR TITLE
feat: add ability to alter lsp file operation timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,8 +166,14 @@ require("oil").setup({
   -- Set to true to autosave buffers that are updated with LSP willRenameFiles
   -- Set to "unmodified" to only save unmodified buffers
   lsp_rename_autosave = false,
-  -- The amount of time LSP waits for file operation before it errors
-  lsp_file_operation_timeout_ms = 1000,
+  -- set various LSP file operation options
+  lsp_file_methods = {
+    -- Time to wait for LSP file operations to complete before skipping
+    timeout_ms = 1000,
+    -- Set to true to autosave buffers that are updated with LSP willRenameFiles
+    -- Set to "unmodified" to only save unmodified buffers
+    lsp_rename_autosave = false,
+  },
   -- Constrain the cursor to the editable parts of the oil buffer
   -- Set to `false` to disable, or "name" to keep it on the file names
   constrain_cursor = "editable",

--- a/README.md
+++ b/README.md
@@ -166,6 +166,8 @@ require("oil").setup({
   -- Set to true to autosave buffers that are updated with LSP willRenameFiles
   -- Set to "unmodified" to only save unmodified buffers
   lsp_rename_autosave = false,
+  -- The amount of time LSP waits for file operation before it errors
+  lsp_file_operation_timeout_ms = 5000,
   -- Constrain the cursor to the editable parts of the oil buffer
   -- Set to `false` to disable, or "name" to keep it on the file names
   constrain_cursor = "editable",

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ require("oil").setup({
   -- Set to "unmodified" to only save unmodified buffers
   lsp_rename_autosave = false,
   -- The amount of time LSP waits for file operation before it errors
-  lsp_file_operation_timeout_ms = 5000,
+  lsp_file_operation_timeout_ms = 1000,
   -- Constrain the cursor to the editable parts of the oil buffer
   -- Set to `false` to disable, or "name" to keep it on the file names
   constrain_cursor = "editable",

--- a/README.md
+++ b/README.md
@@ -163,9 +163,6 @@ require("oil").setup({
   -- You can set the delay to false to disable cleanup entirely
   -- Note that the cleanup process only starts when none of the oil buffers are currently displayed
   cleanup_delay_ms = 2000,
-  -- Set to true to autosave buffers that are updated with LSP willRenameFiles
-  -- Set to "unmodified" to only save unmodified buffers
-  lsp_rename_autosave = false,
   -- set various LSP file operation options
   lsp_file_methods = {
     -- Time to wait for LSP file operations to complete before skipping

--- a/README.md
+++ b/README.md
@@ -163,13 +163,12 @@ require("oil").setup({
   -- You can set the delay to false to disable cleanup entirely
   -- Note that the cleanup process only starts when none of the oil buffers are currently displayed
   cleanup_delay_ms = 2000,
-  -- set various LSP file operation options
   lsp_file_methods = {
     -- Time to wait for LSP file operations to complete before skipping
     timeout_ms = 1000,
     -- Set to true to autosave buffers that are updated with LSP willRenameFiles
     -- Set to "unmodified" to only save unmodified buffers
-    lsp_rename_autosave = false,
+    autosave_changes = false,
   },
   -- Constrain the cursor to the editable parts of the oil buffer
   -- Set to `false` to disable, or "name" to keep it on the file names

--- a/doc/oil.txt
+++ b/doc/oil.txt
@@ -54,9 +54,6 @@ CONFIG                                                                *oil-confi
       -- You can set the delay to false to disable cleanup entirely
       -- Note that the cleanup process only starts when none of the oil buffers are currently displayed
       cleanup_delay_ms = 2000,
-      -- Set to true to autosave buffers that are updated with LSP willRenameFiles
-      -- Set to "unmodified" to only save unmodified buffers
-      lsp_rename_autosave = false,
       -- set various LSP file operation options
       lsp_file_methods = {
         -- Time to wait for LSP file operations to complete before skipping

--- a/doc/oil.txt
+++ b/doc/oil.txt
@@ -57,8 +57,14 @@ CONFIG                                                                *oil-confi
       -- Set to true to autosave buffers that are updated with LSP willRenameFiles
       -- Set to "unmodified" to only save unmodified buffers
       lsp_rename_autosave = false,
-      -- The amount of time LSP waits for file operation before it errors
-      lsp_file_operation_timeout_ms = 1000,
+      -- set various LSP file operation options
+      lsp_file_methods = {
+        -- Time to wait for LSP file operations to complete before skipping
+        timeout_ms = 1000,
+        -- Set to true to autosave buffers that are updated with LSP willRenameFiles
+        -- Set to "unmodified" to only save unmodified buffers
+        lsp_rename_autosave = false,
+      },
       -- Constrain the cursor to the editable parts of the oil buffer
       -- Set to `false` to disable, or "name" to keep it on the file names
       constrain_cursor = "editable",

--- a/doc/oil.txt
+++ b/doc/oil.txt
@@ -54,13 +54,12 @@ CONFIG                                                                *oil-confi
       -- You can set the delay to false to disable cleanup entirely
       -- Note that the cleanup process only starts when none of the oil buffers are currently displayed
       cleanup_delay_ms = 2000,
-      -- set various LSP file operation options
       lsp_file_methods = {
         -- Time to wait for LSP file operations to complete before skipping
         timeout_ms = 1000,
         -- Set to true to autosave buffers that are updated with LSP willRenameFiles
         -- Set to "unmodified" to only save unmodified buffers
-        lsp_rename_autosave = false,
+        autosave_changes = false,
       },
       -- Constrain the cursor to the editable parts of the oil buffer
       -- Set to `false` to disable, or "name" to keep it on the file names

--- a/doc/oil.txt
+++ b/doc/oil.txt
@@ -58,7 +58,7 @@ CONFIG                                                                *oil-confi
       -- Set to "unmodified" to only save unmodified buffers
       lsp_rename_autosave = false,
       -- The amount of time LSP waits for file operation before it errors
-      lsp_file_operation_timeout_ms = 5000,
+      lsp_file_operation_timeout_ms = 1000,
       -- Constrain the cursor to the editable parts of the oil buffer
       -- Set to `false` to disable, or "name" to keep it on the file names
       constrain_cursor = "editable",

--- a/doc/oil.txt
+++ b/doc/oil.txt
@@ -57,6 +57,8 @@ CONFIG                                                                *oil-confi
       -- Set to true to autosave buffers that are updated with LSP willRenameFiles
       -- Set to "unmodified" to only save unmodified buffers
       lsp_rename_autosave = false,
+      -- The amount of time LSP waits for file operation before it errors
+      lsp_file_operation_timeout_ms = 5000,
       -- Constrain the cursor to the editable parts of the oil buffer
       -- Set to `false` to disable, or "name" to keep it on the file names
       constrain_cursor = "editable",

--- a/lua/oil/config.lua
+++ b/lua/oil/config.lua
@@ -37,13 +37,14 @@ local default_config = {
   -- You can set the delay to false to disable cleanup entirely
   -- Note that the cleanup process only starts when none of the oil buffers are currently displayed
   cleanup_delay_ms = 2000,
-  -- Set to true to autosave buffers that are updated with LSP willRenameFiles
-  -- Set to "unmodified" to only save unmodified buffers
-  lsp_rename_autosave = false,
-
-  -- The amount of time LSP waits for file operation before it errors
-  lsp_file_operation_timeout_ms = 1000,
-
+  -- set various LSP file operation options
+  lsp_file_methods = {
+    -- Time to wait for LSP file operations to complete before skipping
+    timeout_ms = 1000,
+    -- Set to true to autosave buffers that are updated with LSP willRenameFiles
+    -- Set to "unmodified" to only save unmodified buffers
+    lsp_rename_autosave = false,
+  },
   -- Constrain the cursor to the editable parts of the oil buffer
   -- Set to `false` to disable, or "name" to keep it on the file names
   constrain_cursor = "editable",

--- a/lua/oil/config.lua
+++ b/lua/oil/config.lua
@@ -42,7 +42,7 @@ local default_config = {
   lsp_rename_autosave = false,
 
   -- The amount of time LSP waits for file operation before it errors
-  lsp_file_operation_timeout_ms = 5000,
+  lsp_file_operation_timeout_ms = 1000,
 
   -- Constrain the cursor to the editable parts of the oil buffer
   -- Set to `false` to disable, or "name" to keep it on the file names

--- a/lua/oil/config.lua
+++ b/lua/oil/config.lua
@@ -40,6 +40,10 @@ local default_config = {
   -- Set to true to autosave buffers that are updated with LSP willRenameFiles
   -- Set to "unmodified" to only save unmodified buffers
   lsp_rename_autosave = false,
+
+  -- The amount of time LSP waits for file operation before it errors
+  lsp_file_operation_timeout_ms = 5000,
+
   -- Constrain the cursor to the editable parts of the oil buffer
   -- Set to `false` to disable, or "name" to keep it on the file names
   constrain_cursor = "editable",

--- a/lua/oil/config.lua
+++ b/lua/oil/config.lua
@@ -37,13 +37,12 @@ local default_config = {
   -- You can set the delay to false to disable cleanup entirely
   -- Note that the cleanup process only starts when none of the oil buffers are currently displayed
   cleanup_delay_ms = 2000,
-  -- set various LSP file operation options
   lsp_file_methods = {
     -- Time to wait for LSP file operations to complete before skipping
     timeout_ms = 1000,
     -- Set to true to autosave buffers that are updated with LSP willRenameFiles
     -- Set to "unmodified" to only save unmodified buffers
-    lsp_rename_autosave = false,
+    autosave_changes = false,
   },
   -- Constrain the cursor to the editable parts of the oil buffer
   -- Set to `false` to disable, or "name" to keep it on the file names
@@ -175,6 +174,15 @@ M.setup = function(opts)
   local new_conf = vim.tbl_deep_extend("keep", opts or {}, default_config)
   if not new_conf.use_default_keymaps then
     new_conf.keymaps = opts.keymaps or {}
+  end
+
+  if new_conf.lsp_rename_autosave ~= nil then
+    new_conf.lsp_file_methods.autosave_changes = new_conf.lsp_rename_autosave
+    new_conf.lsp_rename_autosave = nil
+    vim.notify_once(
+      "oil config value lsp_rename_autosave has moved to lsp_file_methods.autosave_changes.\nCompatibility will be removed on 2024-09-01.",
+      vim.log.levels.WARN
+    )
   end
 
   for k, v in pairs(new_conf) do

--- a/lua/oil/lsp/helpers.lua
+++ b/lua/oil/lsp/helpers.lua
@@ -69,9 +69,9 @@ M.will_perform_file_operations = function(actions)
     end
   end
   local timeout_ms = config.lsp_file_operation_timeout_ms
-  accum(workspace.will_create_files(creates, { timeout_ms }))
-  accum(workspace.will_delete_files(deletes, { timeout_ms }))
-  accum(workspace.will_rename_files(moves, { timeout_ms }))
+  accum(workspace.will_create_files(creates, { timeout_ms = timeout_ms }))
+  accum(workspace.will_delete_files(deletes, { timeout_ms = timeout_ms }))
+  accum(workspace.will_rename_files(moves, { timeout_ms = timeout_ms }))
   if final_err then
     vim.notify(
       string.format("[lsp] file operation error: %s", vim.inspect(final_err)),

--- a/lua/oil/lsp/helpers.lua
+++ b/lua/oil/lsp/helpers.lua
@@ -86,7 +86,7 @@ M.will_perform_file_operations = function(actions)
 
     local autosave = config.lsp_file_methods.lsp_rename_autosave or config.lsp_rename_autosave
     if config.lsp_rename_autosave ~= nil then
-      vim.deprecate("lsp_rename_autosave will be deprecated. Move the flag inside lsp_file_methods", nil, 'v2.7.0',
+      vim.deprecate("lsp_rename_autosave at root level", nil, 'v2.7.0',
         'oil.nvim',
         false)
     end

--- a/lua/oil/lsp/helpers.lua
+++ b/lua/oil/lsp/helpers.lua
@@ -84,13 +84,7 @@ M.will_perform_file_operations = function(actions)
     workspace.did_delete_files(deletes)
     workspace.did_rename_files(moves)
 
-    local autosave = config.lsp_file_methods.lsp_rename_autosave or config.lsp_rename_autosave
-    if config.lsp_rename_autosave ~= nil then
-      vim.deprecate("lsp_rename_autosave at root level", nil, 'v2.7.0',
-        'oil.nvim',
-        false)
-    end
-
+    local autosave = config.lsp_file_methods.autosave_changes
     if autosave == false then
       return
     end

--- a/lua/oil/lsp/helpers.lua
+++ b/lua/oil/lsp/helpers.lua
@@ -68,9 +68,10 @@ M.will_perform_file_operations = function(actions)
       end
     end
   end
-  accum(workspace.will_create_files(creates))
-  accum(workspace.will_delete_files(deletes))
-  accum(workspace.will_rename_files(moves))
+  local timeout_ms = config.lsp_file_operation_timeout_ms
+  accum(workspace.will_create_files(creates, { timeout_ms }))
+  accum(workspace.will_delete_files(deletes, { timeout_ms }))
+  accum(workspace.will_rename_files(moves, { timeout_ms }))
   if final_err then
     vim.notify(
       string.format("[lsp] file operation error: %s", vim.inspect(final_err)),

--- a/lua/oil/lsp/helpers.lua
+++ b/lua/oil/lsp/helpers.lua
@@ -68,7 +68,7 @@ M.will_perform_file_operations = function(actions)
       end
     end
   end
-  local timeout_ms = config.lsp_file_operation_timeout_ms
+  local timeout_ms = config.lsp_file_methods.timeout_ms
   accum(workspace.will_create_files(creates, { timeout_ms = timeout_ms }))
   accum(workspace.will_delete_files(deletes, { timeout_ms = timeout_ms }))
   accum(workspace.will_rename_files(moves, { timeout_ms = timeout_ms }))
@@ -84,7 +84,13 @@ M.will_perform_file_operations = function(actions)
     workspace.did_delete_files(deletes)
     workspace.did_rename_files(moves)
 
-    local autosave = config.lsp_rename_autosave
+    local autosave = config.lsp_file_methods.lsp_rename_autosave or config.lsp_rename_autosave
+    if config.lsp_rename_autosave ~= nil then
+      vim.deprecate("lsp_rename_autosave will be deprecated. Move the flag inside lsp_file_methods", nil, 'v2.7.0',
+        'oil.nvim',
+        false)
+    end
+
     if autosave == false then
       return
     end

--- a/lua/oil/lsp/workspace.lua
+++ b/lua/oil/lsp/workspace.lua
@@ -146,7 +146,7 @@ local function will_file_operation(method, capability_name, files, options)
         end, matching_files),
       }
       ---@diagnostic disable-next-line: invisible
-      local result, err = client.request_sync(method, params, options.timeout_ms, 0)
+      local result, err = client.request_sync(method, params, options.timeout_ms or 1000, 0)
       if result and result.result then
         if options.apply_edits ~= false then
           vim.lsp.util.apply_workspace_edit(result.result, client.offset_encoding)
@@ -260,7 +260,7 @@ function M.will_rename_files(files, options)
       }
       local result, err =
         ---@diagnostic disable-next-line: invisible
-        client.request_sync(ms.workspace_willRenameFiles, params, options.timeout_ms, 0)
+        client.request_sync(ms.workspace_willRenameFiles, params, options.timeout_ms or 1000, 0)
       if result and result.result then
         if options.apply_edits ~= false then
           vim.lsp.util.apply_workspace_edit(result.result, client.offset_encoding)

--- a/lua/oil/lsp/workspace.lua
+++ b/lua/oil/lsp/workspace.lua
@@ -260,7 +260,7 @@ function M.will_rename_files(files, options)
       }
       local result, err =
         ---@diagnostic disable-next-line: invisible
-        client.request_sync(ms.workspace_willRenameFiles, params, options.timeout_ms or 1000, 0)
+        client.request_sync(ms.workspace_willRenameFiles, params, options.timeout_ms, 0)
       if result and result.result then
         if options.apply_edits ~= false then
           vim.lsp.util.apply_workspace_edit(result.result, client.offset_encoding)

--- a/lua/oil/lsp/workspace.lua
+++ b/lua/oil/lsp/workspace.lua
@@ -146,7 +146,7 @@ local function will_file_operation(method, capability_name, files, options)
         end, matching_files),
       }
       ---@diagnostic disable-next-line: invisible
-      local result, err = client.request_sync(method, params, options.timeout_ms or 1000, 0)
+      local result, err = client.request_sync(method, params, options.timeout_ms, 0)
       if result and result.result then
         if options.apply_edits ~= false then
           vim.lsp.util.apply_workspace_edit(result.result, client.offset_encoding)


### PR DESCRIPTION
I have a large repo in typescript where 1000ms is not enough time for LSP to resolve my rename file request. Therefore, I want to add a config that allows the user to alter the timeout, while keeping the default of 1000ms