### PR TITLE
feat: run external commands on a file under the cursor

### DIFF
--- a/lua/oil/actions.lua
+++ b/lua/oil/actions.lua
@@ -403,8 +403,7 @@ M.run_external = {
       if file == "" then
         return
       end
-      local output = vim.fn.system(command .. file)
-      vim.print(output)
+      vim.api.nvim_command(":! " .. command .. " \"" .. file_path .. "\"")
     end)
   end
 }

--- a/lua/oil/actions.lua
+++ b/lua/oil/actions.lua
@@ -392,4 +392,21 @@ M._get_actions = function()
   return ret
 end
 
+M.run_external = {
+  desc = "Run an external command on an entry",
+  callback = function()
+    vim.ui.input({ prompt = "command: ", completion = "shellcmd" }, function(command)
+      if command == "" then
+        return
+      end
+      local file = oil.get_current_dir() .. oil.get_cursor_entry().name
+      if file == "" then
+        return
+      end
+      local output = vim.fn.system(command .. file)
+      vim.print(output)
+    end)
+  end
+}
+
 return M

--- a/lua/oil/actions.lua
+++ b/lua/oil/actions.lua
@@ -403,7 +403,7 @@ M.run_external = {
       if file == "" then
         return
       end
-      vim.api.nvim_command(":! " .. command .. " \"" .. file_path .. "\"")
+      vim.api.nvim_command(":! " .. command .. " \"" .. file .. "\"")
     end)
   end
 }

--- a/lua/oil/config.lua
+++ b/lua/oil/config.lua
@@ -68,6 +68,7 @@ local default_config = {
     ["gx"] = "actions.open_external",
     ["g."] = "actions.toggle_hidden",
     ["g\\"] = "actions.toggle_trash",
+    ["g:"] = "actions.run_external",
   },
   -- Configuration for the floating keymaps help window
   keymaps_help = {


### PR DESCRIPTION
By doing "g:" on a file a prompt asks us which command to run on the current file under the cursor. This is helpful when we want to run a quick command like `file` or `ldd`.