### PR TITLE
Sort entries with natural sorting

### DIFF
--- a/lua/oil/columns.lua
+++ b/lua/oil/columns.lua
@@ -279,6 +279,10 @@ M.register("type", {
   end,
 })
 
+local function pad_number(int)
+  return string.format("%012d", int)
+end
+
 M.register("name", {
   render = function(entry, conf)
     error("Do not use the name column. It is for sorting only")
@@ -289,7 +293,11 @@ M.register("name", {
   end,
 
   get_sort_value = function(entry)
-    return entry[FIELD_NAME]
+    if config.view_options.natural_order then
+      return entry[FIELD_NAME]:gsub("%d+", pad_number)
+    else
+      return entry[FIELD_NAME]
+    end
   end,
 })
 

--- a/lua/oil/config.lua
+++ b/lua/oil/config.lua
@@ -90,6 +90,9 @@ local default_config = {
     is_always_hidden = function(name, bufnr)
       return false
     end,
+    -- Sort file names in a more intuitive order for humans. Is less performant,
+    -- so you may want to set to false if you work with large directories.
+    natural_order = true,
     sort = {
       -- sort order can be "asc" or "desc"
       -- see :help oil-columns to see which columns are sortable

--- a/lua/oil/view.lua
+++ b/lua/oil/view.lua
@@ -515,6 +515,32 @@ M.initialize = function(bufnr)
   keymap_util.set_keymaps(config.keymaps, bufnr)
 end
 
+--- Compare two strings while also treating multi-digit integers atomically
+---@param a_val string
+---@param b_val string
+---@param order string
+---@return boolean
+local function natural_sort_compare(a_val, b_val, order)
+  ---This method pads integers with zeroes so that they are always 12 digits long.
+  ---As a result, comparing strings that have integers of different sizes work
+  ---as if we were comparing integers (instead of strings of integers)
+  ---
+  ---Note: if the file name has integers of more than 12 digits, this padding does not work
+  ---@param int integer
+  local function pad_to_compare(int)
+    return string.format("%012d", int)
+  end
+
+  local a_val_padded = string.gsub(a_val, "%d+", pad_to_compare)
+  local b_val_padded = string.gsub(b_val, "%d+", pad_to_compare)
+
+  if order == "desc" then
+    return a_val_padded > b_val_padded
+  else
+    return a_val_padded < b_val_padded
+  end
+end
+
 ---@param adapter oil.Adapter
 ---@return fun(a: oil.InternalEntry, b: oil.InternalEntry): boolean
 local function get_sort_function(adapter)
@@ -547,11 +573,7 @@ local function get_sort_function(adapter)
       local a_val = get_sort_value(a)
       local b_val = get_sort_value(b)
       if a_val ~= b_val then
-        if order == "desc" then
-          return a_val > b_val
-        else
-          return a_val < b_val
-        end
+        return natural_sort_compare(a_val, b_val, order)
       end
     end
     return a[FIELD_NAME] < b[FIELD_NAME]


### PR DESCRIPTION
Does #306. Some screenshots of Oil after this change:

## With default sorting
<img width="299" alt="image" src="https://github.com/stevearc/oil.nvim/assets/5667047/689b98cc-70cb-4b0c-a612-e80bd0cd98f5">

Before, the file `15` would come before `9`. Likewise, `v114.lua` would come before `v24.lua`

## With descending name
<img width="377" alt="image" src="https://github.com/stevearc/oil.nvim/assets/5667047/da7243f9-c54f-48ba-a963-9603e64d5a20">

Happy to make this an optional feature!