### PR TITLE
feat: add copy filename action

### DIFF
--- a/doc/oil.txt
+++ b/doc/oil.txt
@@ -451,6 +451,9 @@ change_sort                                                  *actions.change_sor
 close                                                              *actions.close*
     Close oil and restore original buffer
 
+copy_entry_filename                                  *actions.copy_entry_filename*
+    Yank the filename of the entry under the cursor to a register
+
 copy_entry_path                                          *actions.copy_entry_path*
     Yank the filepath of the entry under the cursor to a register
 

--- a/lua/oil/actions.lua
+++ b/lua/oil/actions.lua
@@ -271,6 +271,17 @@ M.copy_entry_path = {
   end,
 }
 
+M.copy_entry_filename = {
+  desc = "Yank the filename of the entry under the cursor to a register",
+  callback = function()
+    local entry = oil.get_cursor_entry()
+    if not entry then
+      return
+    end
+    vim.fn.setreg(vim.v.register, entry.name)
+  end,
+}
+
 M.open_cmdline_dir = {
   desc = "Open vim cmdline with current directory as an argument",
   callback = function()


### PR DESCRIPTION
Adds an action similar to `copy_entry_path`, but instead just copy the filename (without the path).