### PR TITLE
Return from delete_hidden_buffers when win type is command

### DIFF
--- a/lua/oil/view.lua
+++ b/lua/oil/view.lua
@@ -212,8 +212,12 @@ end
 ---Delete unmodified, hidden oil buffers and if none remain, clear the cache
 M.delete_hidden_buffers = function()
   local visible_buffers, hidden_buffers = get_visible_hidden_buffers()
-  if not visible_buffers or not hidden_buffers or not vim.tbl_isempty(visible_buffers)
-      or vim.fn.win_gettype() == "command" then
+  if
+    not visible_buffers
+    or not hidden_buffers
+    or not vim.tbl_isempty(visible_buffers)
+    or vim.fn.win_gettype() == "command"
+  then
     return
   end
   for _, bufnr in ipairs(hidden_buffers) do

--- a/lua/oil/view.lua
+++ b/lua/oil/view.lua
@@ -212,7 +212,8 @@ end
 ---Delete unmodified, hidden oil buffers and if none remain, clear the cache
 M.delete_hidden_buffers = function()
   local visible_buffers, hidden_buffers = get_visible_hidden_buffers()
-  if not visible_buffers or not hidden_buffers or not vim.tbl_isempty(visible_buffers) then
+  if not visible_buffers or not hidden_buffers or not vim.tbl_isempty(visible_buffers)
+      or vim.fn.win_gettype() == "command" then
     return
   end
   for _, bufnr in ipairs(hidden_buffers) do


### PR DESCRIPTION
Fixes an issue where attempting to delete hidden buffers when in a command window throws an error.

Ref: https://github.com/stevearc/oil.nvim/issues/390