### PR TITLE
feat: notify when changing the current directory

### DIFF
--- a/lua/oil/actions.lua
+++ b/lua/oil/actions.lua
@@ -102,7 +102,7 @@ local function cd(cmd)
   local dir = oil.get_current_dir()
   if dir then
     vim.cmd({ cmd = cmd, args = { dir } })
-    vim.notify(string.format("Change directory: %s", dir), vim.log.levels.INFO)
+    vim.notify(string.format("CWD: %s", dir), vim.log.levels.INFO)
   else
     vim.notify("Cannot :cd; not in a directory", vim.log.levels.WARN)
   end

--- a/lua/oil/actions.lua
+++ b/lua/oil/actions.lua
@@ -102,6 +102,7 @@ local function cd(cmd)
   local dir = oil.get_current_dir()
   if dir then
     vim.cmd({ cmd = cmd, args = { dir } })
+    vim.notify(string.format("Change directory: %s", dir), vim.log.levels.INFO)
   else
     vim.notify("Cannot :cd; not in a directory", vim.log.levels.WARN)
   end


### PR DESCRIPTION
Right now both `actions.tcd` and `actions.cd` seem to do their job silently. That made me think the `~` key is broken(https://github.com/stevearc/oil.nvim/issues/397).

We can improve UX by providing these actions with info notifications, so the keypresses provide some visual response to the user.