### PR TITLE
fix: cannot perform file/directory operations within LSP workspaces

### DIFF
--- a/lua/oil/lsp/workspace.lua
+++ b/lua/oil/lsp/workspace.lua
@@ -77,7 +77,7 @@ local function get_matching_paths(client, filters, paths)
       if vim.glob and vim.glob.to_lpeg then
         -- HACK around https://github.com/neovim/neovim/issues/28931
         -- find alternations and sort them by length to try to match the longest first
-        if vim.has("nvim-0.11") == 0 then
+        if vim.fn.has("nvim-0.11") == 0 then
           glob = glob:gsub("{(.*)}", function(s)
             local pieces = vim.split(s, ",")
             table.sort(pieces, function(a, b)


### PR DESCRIPTION
Hi @stevearc, 

This is my very first PR to contribute to the most favorite plugin that I cannot live without. I raise a PR to fix the issue #410.
The root cause of the issue is that the plugin called `vim.has("nvim-0.11")` instead of `vim.fn.has("nvim-0.11")` in the file `lua/oil/lsp/workspace.lua`.

I would really appreciate if you can review my PR.

Thank you so much.