### PR TITLE
fix: vim.has doesn't exist, use vim.fn.has instead

### DIFF
--- a/lua/oil/lsp/workspace.lua
+++ b/lua/oil/lsp/workspace.lua
@@ -77,7 +77,7 @@ local function get_matching_paths(client, filters, paths)
       if vim.glob and vim.glob.to_lpeg then
         -- HACK around https://github.com/neovim/neovim/issues/28931
         -- find alternations and sort them by length to try to match the longest first
-        if vim.has("nvim-0.11") == 0 then
+        if vim.fn.has("nvim-0.11") == 0 then
           glob = glob:gsub("{(.*)}", function(s)
             local pieces = vim.split(s, ",")
             table.sort(pieces, function(a, b)


### PR DESCRIPTION
It errors when you try to rename a file otherwise