### PR TITLE
refactor: move loading message delay to config

### DIFF
--- a/lua/oil/config.lua
+++ b/lua/oil/config.lua
@@ -46,6 +46,8 @@ local default_config = {
     -- Set to "unmodified" to only save unmodified buffers
     autosave_changes = false,
   },
+  -- Delay the loading screen just a bit to avoid flicker
+  loading_message_delay = 100,
   -- Constrain the cursor to the editable parts of the oil buffer
   -- Set to `false` to disable, or "name" to keep it on the file names
   constrain_cursor = "editable",

--- a/lua/oil/loading.lua
+++ b/lua/oil/loading.lua
@@ -1,3 +1,4 @@
+local config = require("oil.config")
 local util = require("oil.util")
 local M = {}
 
@@ -67,7 +68,8 @@ M.set_loading = function(bufnr, is_loading)
       timers[bufnr] = vim.loop.new_timer()
       local bar_iter = M.get_bar_iter({ width = width })
       timers[bufnr]:start(
-        100, -- Delay the loading screen just a bit to avoid flicker
+        -- Delay the loading screen just a bit to avoid flicker
+        config.loading_message_delay,
         math.floor(1000 / FPS),
         vim.schedule_wrap(function()
           if not vim.api.nvim_buf_is_valid(bufnr) or not timers[bufnr] then

--- a/lua/oil/types.lua
+++ b/lua/oil/types.lua
@@ -9,6 +9,7 @@
 ---@field cleanup_delay_ms? integer Oil will automatically delete hidden buffers after this delay. You can set the delay to false to disable cleanup entirely. Note that the cleanup process only starts when none of the oil buffers are currently displayed.
 ---@field lsp_file_methods? oil.LspFileMethods Configure LSP file operation integration.
 ---@field constrain_cursor? false|"name"|"editable" Constrain the cursor to the editable parts of the oil buffer. Set to `false` to disable, or "name" to keep it on the file names.
+---@field loading_message_delay? integer set the delay for the loading screen just a bit to avoid flicker
 ---@field experimental_watch_for_changes? boolean Set to true to watch the filesystem for changes and reload oil.
 ---@field keymaps? table<string, any>
 ---@field use_default_keymaps? boolean Set to false to disable all of the above keymaps


### PR DESCRIPTION
This allows `loading_message_delay` to be overridden