### PR TITLE
feat: improve is_modifiable checks for unix os's

### DIFF
--- a/lua/oil/adapters/files.lua
+++ b/lua/oil/adapters/files.lua
@@ -433,14 +433,21 @@ M.is_modifiable = function(bufnr)
   end
 
   local uid = uv.getuid()
-  local gid = uv.getgid()
+  local gids = vim.fn.split(vim.fn.system("id -G"))
   local rwx
   if uid == stat.uid then
     rwx = bit.rshift(stat.mode, 6)
-  elseif gid == stat.gid then
-    rwx = bit.rshift(stat.mode, 3)
   else
-    rwx = stat.mode
+    local in_group = false
+    for _, gid in ipairs(gids) do
+      if tonumber(gid) == stat.gid then
+        rwx = bit.rshift(stat.mode, 3)
+        in_group = true
+      end
+    end
+    if not in_group then
+      rwx = stat.mode
+    end
   end
   return bit.band(rwx, 2) ~= 0
 end

--- a/lua/oil/adapters/files.lua
+++ b/lua/oil/adapters/files.lua
@@ -446,7 +446,8 @@ M.is_modifiable = function(bufnr)
   local rwx = stat.mode
   if proc_uid == stat.uid then
     rwx = bit.bor(rwx, bit.rshift(stat.mode, 6))
-  elseif user_gids ~= nil then
+  end
+  if user_gids ~= nil then
     if vim.tbl_contains(user_gids, tostring(stat.gid)) then
       rwx = bit.bor(rwx, bit.rshift(stat.mode, 3))
     end

--- a/lua/oil/cache.lua
+++ b/lua/oil/cache.lua
@@ -18,9 +18,6 @@ local entries_by_id = {}
 ---@type table<integer, string>
 local parent_url_by_id = {}
 
----@type table<integer, string>
-local user_gids = {}
-
 -- Temporary map while a directory is being updated
 local tmp_url_directory = {}
 
@@ -41,7 +38,6 @@ M.clear_everything = function()
   url_directory = {}
   entries_by_id = {}
   parent_url_by_id = {}
-  user_gids = {}
 end
 
 ---@param parent_url string
@@ -203,19 +199,6 @@ M.perform_action = function(action)
   else
     error(string.format("Bad action type: '%s'", action.type))
   end
-end
-
----@return nil|table<integer, string>
-M.get_user_gids = function()
-  if not vim.tbl_isempty(user_gids) then
-    return user_gids
-  end
-  return nil
-end
-
----@param gids table<integer, string>
-M.set_user_gids = function(gids)
-  user_gids = gids
 end
 
 return M

--- a/lua/oil/cache.lua
+++ b/lua/oil/cache.lua
@@ -18,6 +18,9 @@ local entries_by_id = {}
 ---@type table<integer, string>
 local parent_url_by_id = {}
 
+---@type table<integer, string>
+local user_gids = {}
+
 -- Temporary map while a directory is being updated
 local tmp_url_directory = {}
 
@@ -38,6 +41,7 @@ M.clear_everything = function()
   url_directory = {}
   entries_by_id = {}
   parent_url_by_id = {}
+  user_gids = {}
 end
 
 ---@param parent_url string
@@ -199,6 +203,19 @@ M.perform_action = function(action)
   else
     error(string.format("Bad action type: '%s'", action.type))
   end
+end
+
+---@return nil|table<integer, string>
+M.get_user_gids = function()
+  if not vim.tbl_isempty(user_gids) then
+    return user_gids
+  end
+  return nil
+end
+
+---@param gids table<integer, string>
+M.set_user_gids = function(gids)
+  user_gids = gids
 end
 
 return M


### PR DESCRIPTION
## About
This will resolve #342, it improves the `is_modifiable` function for directories on unix systems by more accurately checking whether the user has write permission for the directory.

This PR changes the function so that it:
- Checks the groups that the nvim process owner is a part of, instead of only the group that nvim was launched with, this is done using the `id -G` command (gets all gid's of groups that the user is in) and checking if directory gid is in this list.
    * note: the command output is cached upon first run if successful
    * note: if the command fails it falls back to the previous behavior of only checking if the directory gid equal to the nvim process gid
- Accounts for weirder permission setups e.g. 170 and 117 (where the user is the owner of the directory) by still checking the group and others permission sets, and doing an bitwise OR with all of the permission sets that they match.

### Questions
- Is the way I went about the cache fine? I saw that the current cache implementation was based around paths, however since the command `id -G` is independent of directories (based on the nvim process user), I just added an extra variable to the cache module with functions to get and set it.
- With the current cache, even if the command fails for one directory it will try again for the next directory the user enters, should I just make it so that if it fails the first time to not try again, or can I leave it as is?