### PR TITLE
feat: add support for `mini.icons`

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,9 @@ https://user-images.githubusercontent.com/506791/209727111-6b4a11f4-634a-4efa-94
 ## Requirements
 
 - Neovim 0.8+
-- (optional) [nvim-web-devicons](https://github.com/nvim-tree/nvim-web-devicons) for file icons
+- Icon provider plugin (optional)
+  - [mini.icons](https://github.com/echasnovski/mini.nvim/blob/main/readmes/mini-icons.md) for file and folder icons
+  - [nvim-web-devicons](https://github.com/nvim-tree/nvim-web-devicons) for file icons
 
 ## Installation
 
@@ -34,7 +36,8 @@ oil.nvim supports all the usual plugin managers
   'stevearc/oil.nvim',
   opts = {},
   -- Optional dependencies
-  dependencies = { "nvim-tree/nvim-web-devicons" },
+  dependencies = { "echasnovski/mini.icons" },
+  -- dependencies = { "nvim-tree/nvim-web-devicons" }, -- use if prefer nvim-web-devicons
 }
 ```
 

--- a/lua/oil/columns.lua
+++ b/lua/oil/columns.lua
@@ -1,7 +1,6 @@
 local config = require("oil.config")
 local constants = require("oil.constants")
 local util = require("oil.util")
-local has_devicons, devicons = pcall(require, "nvim-web-devicons")
 local M = {}
 
 local FIELD_NAME = constants.FIELD_NAME
@@ -202,7 +201,8 @@ M.perform_change_action = function(adapter, action, callback)
   column.perform_action(action, callback)
 end
 
-if has_devicons then
+local icon_provider = util.get_icon_provider()
+if icon_provider then
   M.register("icon", {
     render = function(entry, conf)
       local field_type = entry[FIELD_TYPE]
@@ -216,17 +216,10 @@ if has_devicons then
           field_type = meta.link_stat.type
         end
       end
-      local icon, hl
-      if field_type == "directory" then
-        icon = conf and conf.directory or ""
-        hl = "OilDirIcon"
-      else
-        if meta and meta.display_name then
-          name = meta.display_name
-        end
-        icon, hl = devicons.get_icon(name)
-        icon = icon or (conf and conf.default_file or "")
+      if meta and meta.display_name then
+        name = meta.display_name
       end
+      local icon, hl = icon_provider(field_type, name, conf)
       if not conf or conf.add_padding ~= false then
         icon = icon .. " "
       end

--- a/lua/oil/util.lua
+++ b/lua/oil/util.lua
@@ -8,6 +8,8 @@ local FIELD_NAME = constants.FIELD_NAME
 local FIELD_TYPE = constants.FIELD_TYPE
 local FIELD_META = constants.FIELD_META
 
+---@alias oil.IconProvider fun(type: string, name: string, conf: table?): (icon: string, hl: string)
+
 ---@param url string
 ---@return nil|string
 ---@return nil|string
@@ -855,6 +857,32 @@ M.get_edit_path = function(bufnr, entry, callback)
     adapter.get_entry_path(url, entry, callback)
   else
     adapter.normalize_url(url, callback)
+  end
+end
+
+--- Check for an icon provider and return a common icon provider API
+---@return (oil.IconProvider)?
+M.get_icon_provider = function()
+  -- prefer mini.icons
+  local has_mini_icons, mini_icons = pcall(require, "mini.icons")
+  if has_mini_icons then
+    return function(type, name)
+      return mini_icons.get(type == "directory" and "directory" or "file", name)
+    end
+  end
+
+  -- fallback to `nvim-web-devicons`
+  local has_devicons, devicons = pcall(require, "nvim-web-devicons")
+  if has_devicons then
+    return function(type, name, conf)
+      if type == "directory" then
+        return conf and conf.directory or "", "OilDirIcon"
+      else
+        local icon, hl = devicons.get_icon(name)
+        icon = icon or (conf and conf.default_file or "")
+        return icon, hl
+      end
+    end
   end
 end
 


### PR DESCRIPTION
This adds explicit support for [`mini.icons`](https://github.com/echasnovski/mini.nvim/blob/main/readmes/mini-icons.md) for providing icons to oil. This generalizes the icon providing into a function that figures out which icon provider is available (preferring `mini.icons` over `nvim-web-devicons`) and returning a common icon providing interface.

`mini.icons` also has the ability to provide directory icons so this allows the icon provider to provide any type of icon and it's up to the provider to figure out how to handle what it can.

![2024-07-05_09:48:45_screenshot](https://github.com/stevearc/oil.nvim/assets/1591837/c9b1258c-fb53-4b6d-9c0d-ef5b6080a2bf)
![2024-07-05_09:48:59_screenshot](https://github.com/stevearc/oil.nvim/assets/1591837/555ccc58-789d-4270-bbaa-6591a0f22203)


I tested it with each plugin individually as well as both and neither. It is working great! Let me know what you think of the implementation or if you have any recommendations to refactor this. I tried to match the code style and conventions in the codebase.


Thanks so much for such a great project!