### PR TITLE
feat: allow bufnr optional parameter for get_current_dir function

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -83,10 +83,14 @@ Change how oil determines if the file is hidden
 Toggle hidden files and directories
 
 
-## get_current_dir()
+## get_current_dir(bufnr)
 
-`get_current_dir(): nil|string` \
+`get_current_dir(bufnr): nil|string` \
 Get the current directory
+
+| Param | Type           | Desc                                          |
+| ----- | -------------- | --------------------------------------------- |
+| bufnr | `nil\|integer` | When nil, get directory of the current buffer |
 
 
 ## open_float(dir)

--- a/doc/oil.txt
+++ b/doc/oil.txt
@@ -277,9 +277,11 @@ toggle_hidden()                                                *oil.toggle_hidde
     Toggle hidden files and directories
 
 
-get_current_dir(): nil|string                                *oil.get_current_dir*
+get_current_dir({bufnr}): nil|string                         *oil.get_current_dir*
     Get the current directory
 
+    Parameters:
+      {bufnr} `integer` When nil, get directory of the current buffer
 
 open_float({dir})                                                 *oil.open_float*
     Open oil browser in a floating window

--- a/lua/oil/init.lua
+++ b/lua/oil/init.lua
@@ -140,12 +140,14 @@ M.toggle_hidden = function()
 end
 
 ---Get the current directory
+---@param bufnr? integer
 ---@return nil|string
-M.get_current_dir = function()
+M.get_current_dir = function(bufnr)
   local config = require("oil.config")
   local fs = require("oil.fs")
   local util = require("oil.util")
-  local scheme, path = util.parse_url(vim.api.nvim_buf_get_name(0))
+  local buf_name = vim.api.nvim_buf_get_name(bufnr or 0)
+  local scheme, path = util.parse_url(buf_name)
   if config.adapters[scheme] == "files" then
     assert(path)
     return fs.posix_to_os_path(path)


### PR DESCRIPTION
Hi @stevearc, (big fan of your plugin here)

I had a small problem while integrating Oil with a tabline/statusline plugin (lualine.nvim). The problem was that sometimes I had multiple buffers open and Oil buffer wasn't always the currently hovered one. In such cases `get_current_dir` is not working as one would expect as it has a hardcoded reference to buffer `0`. My patch simply adds an optional parameter `bufnr` to said function to make it usable in such cases. This should not break the API in any way and I updated the documentation accordingly. If I screwed something up the PR is open for your edits :)

Cheers!