### PR TITLE
fix: correctly check if `mini.icons` is actually setup

### DIFF
--- a/lua/oil/util.lua
+++ b/lua/oil/util.lua
@@ -864,8 +864,9 @@ end
 ---@return (oil.IconProvider)?
 M.get_icon_provider = function()
   -- prefer mini.icons
-  local has_mini_icons, mini_icons = pcall(require, "mini.icons")
-  if has_mini_icons then
+  local _, mini_icons = pcall(require, "mini.icons")
+  ---@diagnostic disable-next-line: undefined-field
+  if _G.MiniIcons then -- `_G.MiniIcons` is a better check to see if the module is setup
     return function(type, name)
       return mini_icons.get(type == "directory" and "directory" or "file", name)
     end


### PR DESCRIPTION
Some users may be using the full `mini.nvim` suite where `pcall(require, "mini.icons")` will return true but doesn't mean the user has actually set it up. This verifies that it is set up by checking for the existence of `_G.MiniIcons`.

This leaves the `pcall` just so (1) we load the plugin if it is lazy loaded by the user and (2) we get LSP completion/validation with that type as well.