### PR TITLE
Adding support for moving an existing file to a subdirectory

### DIFF
--- a/lua/oil/mutator/init.lua
+++ b/lua/oil/mutator/init.lua
@@ -93,6 +93,25 @@ M.create_actions_from_diffs = function(all_diffs)
     for _, diff in ipairs(diffs) do
       if diff.type == "new" then
         if diff.id then
+          -- Parse nested files like foo/bar/baz
+          -- Create the parent directories if they don't exist
+          local path_sep = fs.is_windows and "[/\\]" or "/"
+          local pieces = vim.split(diff.name, path_sep)
+          local url = parent_url:gsub("/$", "")
+          for i, v in ipairs(pieces) do
+            if i == #pieces then
+              break
+            end
+
+            url = url .. "/" .. v
+            add_action({
+              type = "create",
+              url = url,
+              entry_type = "directory",
+              link = diff.link,
+            })
+          end
+
           local by_id = diff_by_id[diff.id]
           ---HACK: set the destination on this diff for use later
           ---@diagnostic disable-next-line: inject-field

--- a/lua/oil/mutator/parser.lua
+++ b/lua/oil/mutator/parser.lua
@@ -216,8 +216,6 @@ M.parse = function(bufnr)
         err_message = "No filename found"
       elseif not entry then
         err_message = "Could not find existing entry (was the ID changed?)"
-      elseif parsed_entry.name:match("/") or parsed_entry.name:match(fs.sep) then
-        err_message = "Filename cannot contain path separator"
       end
       if err_message then
         table.insert(errors, {

--- a/tests/mutator_spec.lua
+++ b/tests/mutator_spec.lua
@@ -102,6 +102,32 @@ a.describe("mutator", function()
       }, actions)
     end)
 
+    it("constructs MOVE actions with a new subdirectory", function()
+      local file = test_adapter.test_set("/foo/a.txt", "file")
+      vim.cmd.edit({ args = { "oil-test:///foo/" } })
+      local bufnr = vim.api.nvim_get_current_buf()
+      local diffs = {
+        { type = "delete", name = "a.txt", id = file[FIELD_ID] },
+        { type = "new", name = "bar/a.txt", entry_type = "file", id = file[FIELD_ID] },
+      }
+      local actions = mutator.create_actions_from_diffs({
+        [bufnr] = diffs,
+      })
+      assert.are.same({
+        {
+          type = "create",
+          entry_type = "directory",
+          url = "oil-test:///foo/bar",
+        },
+        {
+          type = "move",
+          entry_type = "file",
+          src_url = "oil-test:///foo/a.txt",
+          dest_url = "oil-test:///foo/bar/a.txt",
+        },
+      }, actions)
+    end)
+
     it("correctly orders MOVE + CREATE", function()
       local file = test_adapter.test_set("/a.txt", "file")
       vim.cmd.edit({ args = { "oil-test:///" } })

--- a/tests/parser_spec.lua
+++ b/tests/parser_spec.lua
@@ -194,6 +194,20 @@ describe("parser", function()
     }, diffs)
   end)
 
+  it("parses a rename with new subdirectory", function()
+    local file = test_adapter.test_set("/foo/a.txt", "file")
+    vim.cmd.edit({ args = { "oil-test:///foo/" } })
+    local bufnr = vim.api.nvim_get_current_buf()
+    set_lines(bufnr, {
+      string.format("/%d bar/a.txt", file[FIELD_ID]),
+    })
+    local diffs = parser.parse(bufnr)
+    assert.are.same({
+      { type = "new", id = file[FIELD_ID], name = "bar/a.txt", entry_type = "file" },
+      { type = "delete", id = file[FIELD_ID], name = "a.txt" },
+    }, diffs)
+  end)
+
   it("detects a new trailing slash as a delete + create", function()
     local file = test_adapter.test_set("/foo", "file")
     vim.cmd.edit({ args = { "oil-test:///" } })


### PR DESCRIPTION
Previously an oil window with

```
foo.txt
```
changing to: 
```
bar/foo.txt
```
would result in the following error "Filename cannot contain path separator"

With this change, running the above change will create a subdirectory `bar` if it doesn't exist and will move `foo.txt` inside