### PR TITLE
feat: allow for toggling of gitignored files

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ require("oil").setup({
     ["gs"] = "actions.change_sort",
     ["gx"] = "actions.open_external",
     ["g."] = "actions.toggle_hidden",
+    ["gI"] = "actions.toggle_ignored",
     ["g\\"] = "actions.toggle_trash",
   },
   -- Set to false to disable all of the above keymaps
@@ -208,6 +209,8 @@ require("oil").setup({
   view_options = {
     -- Show files and directories that start with "."
     show_hidden = false,
+    -- Show files and directories specified in ".gitignore" if present
+    show_ignored = true,
     -- This function defines what is considered a "hidden" file
     is_hidden_file = function(name, bufnr)
       return vim.startswith(name, ".")
@@ -332,7 +335,6 @@ Note that at the moment the ssh adapter does not support Windows machines, and i
 ## Recipes
 
 - [Toggle file detail view](doc/recipes.md#toggle-file-detail-view)
-- [Hide gitignored files](doc/recipes.md#hide-gitignored-files)
 
 ## API
 
@@ -345,6 +347,7 @@ Note that at the moment the ssh adapter does not support Windows machines, and i
 - [set_sort(sort)](doc/api.md#set_sortsort)
 - [set_is_hidden_file(is_hidden_file)](doc/api.md#set_is_hidden_fileis_hidden_file)
 - [toggle_hidden()](doc/api.md#toggle_hidden)
+- [toggle_ignored()](doc/api.md#toggle_ignored)
 - [get_current_dir(bufnr)](doc/api.md#get_current_dirbufnr)
 - [open_float(dir)](doc/api.md#open_floatdir)
 - [toggle_float(dir)](doc/api.md#toggle_floatdir)

--- a/doc/api.md
+++ b/doc/api.md
@@ -9,6 +9,7 @@
 - [set_sort(sort)](#set_sortsort)
 - [set_is_hidden_file(is_hidden_file)](#set_is_hidden_fileis_hidden_file)
 - [toggle_hidden()](#toggle_hidden)
+- [toggle_ignored()](#toggle_ignored)
 - [get_current_dir(bufnr)](#get_current_dirbufnr)
 - [open_float(dir)](#open_floatdir)
 - [toggle_float(dir)](#toggle_floatdir)
@@ -81,6 +82,11 @@ Change how oil determines if the file is hidden
 
 `toggle_hidden()` \
 Toggle hidden files and directories
+
+## toggle_ignored()
+
+`toggle_ignored()` \
+Toggle gitignored files and directories
 
 
 ## get_current_dir(bufnr)

--- a/doc/oil.txt
+++ b/doc/oil.txt
@@ -88,6 +88,7 @@ CONFIG                                                                *oil-confi
         ["gs"] = "actions.change_sort",
         ["gx"] = "actions.open_external",
         ["g."] = "actions.toggle_hidden",
+        ["gI"] = "actions.toggle_ignored",
         ["g\\"] = "actions.toggle_trash",
       },
       -- Set to false to disable all of the above keymaps
@@ -95,6 +96,8 @@ CONFIG                                                                *oil-confi
       view_options = {
         -- Show files and directories that start with "."
         show_hidden = false,
+        -- Show files and directories specified in ".gitignore" if present
+        show_ignored = true,
         -- This function defines what is considered a "hidden" file
         is_hidden_file = function(name, bufnr)
           return vim.startswith(name, ".")
@@ -275,6 +278,9 @@ set_is_hidden_file({is_hidden_file})                      *oil.set_is_hidden_fil
 
 toggle_hidden()                                                *oil.toggle_hidden*
     Toggle hidden files and directories
+
+toggle_ignored()                                              *oil.toggle_ignored*
+    Toggle gitignored files and directories
 
 
 get_current_dir({bufnr}): nil|string                         *oil.get_current_dir*
@@ -562,6 +568,9 @@ show_help                                                      *actions.show_hel
 
 toggle_hidden                                              *actions.toggle_hidden*
     Toggle hidden files and directories
+
+toggle_ignored                                            *actions.toggle_ignored*
+    Toggle gitignored files and directories
 
 toggle_trash                                                *actions.toggle_trash*
     Jump to and from the trash for the current directory

--- a/doc/recipes.md
+++ b/doc/recipes.md
@@ -5,7 +5,6 @@ Have a cool recipe to share? Open a pull request and add it to this doc!
 <!-- TOC -->
 
 - [Toggle file detail view](#toggle-file-detail-view)
-- [Hide gitignored files](#hide-gitignored-files)
 
 <!-- /TOC -->
 
@@ -26,52 +25,6 @@ require("oil").setup({
         end
       end,
     },
-  },
-})
-```
-
-## Hide gitignored files
-
-```lua
-local git_ignored = setmetatable({}, {
-  __index = function(self, key)
-    local proc = vim.system(
-      { "git", "ls-files", "--ignored", "--exclude-standard", "--others", "--directory" },
-      {
-        cwd = key,
-        text = true,
-      }
-    )
-    local result = proc:wait()
-    local ret = {}
-    if result.code == 0 then
-      for line in vim.gsplit(result.stdout, "\n", { plain = true, trimempty = true }) do
-        -- Remove trailing slash
-        line = line:gsub("/$", "")
-        table.insert(ret, line)
-      end
-    end
-
-    rawset(self, key, ret)
-    return ret
-  end,
-})
-
-require("oil").setup({
-  view_options = {
-    is_hidden_file = function(name, _)
-      -- dotfiles are always considered hidden
-      if vim.startswith(name, ".") then
-        return true
-      end
-      local dir = require("oil").get_current_dir()
-      -- if no local directory (e.g. for ssh connections), always show
-      if not dir then
-        return false
-      end
-      -- Check if file is gitignored
-      return vim.list_contains(git_ignored[dir], name)
-    end,
   },
 })
 ```

--- a/lua/oil/actions.lua
+++ b/lua/oil/actions.lua
@@ -192,6 +192,13 @@ M.toggle_hidden = {
   end,
 }
 
+M.toggle_ignored = {
+  desc = "Toggle gitignored files and directories",
+  callback = function()
+    require("oil.view").toggle_ignored()
+  end,
+}
+
 M.open_terminal = {
   desc = "Open a terminal in the current directory",
   callback = function()

--- a/lua/oil/config.lua
+++ b/lua/oil/config.lua
@@ -73,6 +73,7 @@ local default_config = {
     ["gs"] = "actions.change_sort",
     ["gx"] = "actions.open_external",
     ["g."] = "actions.toggle_hidden",
+    ["gI"] = "actions.toggle_ignored",
     ["g\\"] = "actions.toggle_trash",
   },
   -- Set to false to disable all of the above keymaps
@@ -80,6 +81,8 @@ local default_config = {
   view_options = {
     -- Show files and directories that start with "."
     show_hidden = false,
+    -- Show files and directories specified in ".gitignore" if present
+    show_ignored = true,
     -- This function defines what is considered a "hidden" file
     is_hidden_file = function(name, bufnr)
       return vim.startswith(name, ".")

--- a/lua/oil/init.lua
+++ b/lua/oil/init.lua
@@ -139,6 +139,11 @@ M.toggle_hidden = function()
   require("oil.view").toggle_hidden()
 end
 
+---Toggle hidden files and directories
+M.toggle_ignored = function()
+  require("oil.view").toggle_ignored()
+end
+
 ---Get the current directory
 ---@param bufnr? integer
 ---@return nil|string

--- a/lua/oil/types.lua
+++ b/lua/oil/types.lua
@@ -27,6 +27,7 @@
 
 ---@class (exact) oil.ViewOptions
 ---@field show_hidden? boolean Show files and directories that start with "."
+---@field show_ignored? boolean Show files and directories specified in ".gitignore" if present
 ---@field is_hidden_file? fun(name: string, bufnr: integer): boolean This function defines what is considered a "hidden" file
 ---@field is_always_hidden? fun(name: string, bufnr: integer): boolean This function defines what will never be shown, even when `show_hidden` is set
 ---@field natural_order? boolean Sort file names in a more intuitive order for humans. Is less performant, so you may want to set to false if you work with large directories.

--- a/lua/oil/view.lua
+++ b/lua/oil/view.lua
@@ -22,7 +22,8 @@ local last_cursor_entry = {}
 ---@return boolean
 M.should_display = function(name, bufnr)
   return not config.view_options.is_always_hidden(name, bufnr)
-    and (not config.view_options.is_hidden_file(name, bufnr) or config.view_options.show_hidden)
+    and (config.view_options.show_hidden or not config.view_options.is_hidden_file(name, bufnr))
+    and (config.view_options.show_ignored or not util.is_ignored_file(name))
 end
 
 ---@param bufname string
@@ -75,6 +76,16 @@ M.toggle_hidden = function()
     vim.notify("Cannot toggle hidden files when you have unsaved changes", vim.log.levels.WARN)
   else
     config.view_options.show_hidden = not config.view_options.show_hidden
+    M.rerender_all_oil_buffers({ refetch = false })
+  end
+end
+
+M.toggle_ignored = function()
+  local any_modified = are_any_modified()
+  if any_modified then
+    vim.notify("Cannot toggle gitignored files when you have unsaved changes", vim.log.levels.WARN)
+  else
+    config.view_options.show_ignored = not config.view_options.show_ignored
     M.rerender_all_oil_buffers({ refetch = false })
   end
 end


### PR DESCRIPTION
Hi! i'm a big fan of this plugin and thought this feature would be a nice addition, so i figured it'd be a good opportunity to try and contribute!

I saw there was a recipe provided for hiding gitignored files in an oil buffer and found that it was almost what i wanted.  I personally prefer seeing them by default, but then toggling them off when they get in the way, so i thought it'd be nice if there was a toggle option similar to how `toggle_hidden()` works.

this change adds the ability to toggle on and off gitignored files with the default keymap `gI` (this command does nothing if not in a git repo btw).  I'm not partial to `gI` or anything tho, so if you have a better idea for a default keymap i can always change it!

I also updated the docs accordingly and removed the aforementioned recipe since it's now a config option.  I totally understand if this change seems too invasive, so no hard feelings if you wanna close it out!