### PR TITLE
fix: Force standard C locale when getting `ls` input for parsing in SSH

### DIFF
--- a/lua/oil/adapters/ssh/sshfs.lua
+++ b/lua/oil/adapters/ssh/sshfs.lua
@@ -112,7 +112,7 @@ function SSHFS:realpath(path, callback)
       abspath = abspath:sub(1, #abspath - 1)
     end
     self.conn:run(
-      string.format("ls -land --color=never %s", shellescape(abspath)),
+      string.format("LC_ALL=C ls -land --color=never %s", shellescape(abspath)),
       function(ls_err, ls_lines)
         local type
         if ls_err then
@@ -142,7 +142,7 @@ function SSHFS:list_dir(url, path, callback)
   if path ~= "" then
     path_postfix = string.format(" %s", shellescape(path))
   end
-  self.conn:run("LANG=C ls -lan --color=never" .. path_postfix, function(err, lines)
+  self.conn:run("LC_ALL=C ls -lan --color=never" .. path_postfix, function(err, lines)
     if err then
       if err:match("No such file or directory%s*$") then
         -- If the directory doesn't exist, treat the list as a success. We will be able to traverse
@@ -176,7 +176,7 @@ function SSHFS:list_dir(url, path, callback)
       -- If there were any soft links, then we need to run another ls command with -L so that we can
       -- resolve the type of the link target
       self.conn:run(
-        "ls -naLl --color=never" .. path_postfix .. " 2> /dev/null",
+        "LC_ALL=C ls -naLl --color=never" .. path_postfix .. " 2> /dev/null",
         function(link_err, link_lines)
           -- Ignore exit code 1. That just means one of the links could not be resolved.
           if link_err and not link_err:match("^1:") then


### PR DESCRIPTION
The locale on the remote machine might result in an unexpected `ls` line, which crashes when parsing.
Therefore, forcing a known locale when executing `ls` for parsing might be better.