### PR TITLE
Add check for filetype before setting win_options

### DIFF
--- a/lua/oil/view.lua
+++ b/lua/oil/view.lua
@@ -333,10 +333,7 @@ M.initialize = function(bufnr)
   for k, v in pairs(config.buf_options) do
     vim.bo[bufnr][k] = v
   end
-
-  if vim.bo.filetype == "oil" then
-    M.set_win_options()
-  end
+  vim.api.nvim_buf_call(bufnr, M.set_win_options)
 
   vim.api.nvim_create_autocmd("BufHidden", {
     desc = "Delete oil buffers when no longer in use",

--- a/lua/oil/view.lua
+++ b/lua/oil/view.lua
@@ -333,7 +333,11 @@ M.initialize = function(bufnr)
   for k, v in pairs(config.buf_options) do
     vim.bo[bufnr][k] = v
   end
-  M.set_win_options()
+
+  if vim.bo.filetype == "oil" then
+    M.set_win_options()
+  end
+
   vim.api.nvim_create_autocmd("BufHidden", {
     desc = "Delete oil buffers when no longer in use",
     group = "Oil",


### PR DESCRIPTION
Fixes an issue where `win_options` were being applied when opening a file in the jumplist at startup.

Ref: https://github.com/stevearc/oil.nvim/issues/398