### PR TITLE
perf(view): avoid running `is_hidden_file` when `show_hidden` is set

### DIFF
--- a/lua/oil/view.lua
+++ b/lua/oil/view.lua
@@ -22,7 +22,7 @@ local last_cursor_entry = {}
 ---@return boolean
 M.should_display = function(name, bufnr)
   return not config.view_options.is_always_hidden(name, bufnr)
-    and (not config.view_options.is_hidden_file(name, bufnr) or config.view_options.show_hidden)
+    and (config.view_options.show_hidden or not config.view_options.is_hidden_file(name, bufnr))
 end
 
 ---@param bufname string


### PR DESCRIPTION
When `show_hidden` is set, we have no need to run `is_hidden_file`. This changes the order of the boolean logic so that the `show_hidden` value can short circuit the evaluation. This causes a significant performance increase when setting `show_hidden`.