### PR TITLE
fix: only map ~ for normal mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ require("oil").setup({
     ["-"] = "actions.parent",
     ["_"] = "actions.open_cwd",
     ["`"] = "actions.cd",
-    ["~"] = { "actions.cd", opts = { scope = "tab" }, desc = ":tcd to the current oil directory" },
+    ["~"] = { "actions.cd", opts = { scope = "tab" }, desc = ":tcd to the current oil directory", mode = "n" },
     ["gs"] = "actions.change_sort",
     ["gx"] = "actions.open_external",
     ["g."] = "actions.toggle_hidden",

--- a/doc/oil.txt
+++ b/doc/oil.txt
@@ -86,7 +86,7 @@ CONFIG                                                                *oil-confi
         ["-"] = "actions.parent",
         ["_"] = "actions.open_cwd",
         ["`"] = "actions.cd",
-        ["~"] = { "actions.cd", opts = { scope = "tab" }, desc = ":tcd to the current oil directory" },
+        ["~"] = { "actions.cd", opts = { scope = "tab" }, desc = ":tcd to the current oil directory", mode = "n" },
         ["gs"] = "actions.change_sort",
         ["gx"] = "actions.open_external",
         ["g."] = "actions.toggle_hidden",

--- a/lua/oil/config.lua
+++ b/lua/oil/config.lua
@@ -71,7 +71,7 @@ local default_config = {
     ["-"] = "actions.parent",
     ["_"] = "actions.open_cwd",
     ["`"] = "actions.cd",
-    ["~"] = { "actions.cd", opts = { scope = "tab" }, desc = ":tcd to the current oil directory" },
+    ["~"] = { "actions.cd", opts = { scope = "tab" }, desc = ":tcd to the current oil directory", mode = "n" },
     ["gs"] = "actions.change_sort",
     ["gx"] = "actions.open_external",
     ["g."] = "actions.toggle_hidden",


### PR DESCRIPTION
Allows to switch character case with ~ (tilde) in visual mode while preserving existing ~ :tcd functionality.
Related to [1].

[1]: https://github.com/stevearc/oil.nvim/issues/397 "bug: ~ not respected"