### PR TITLE
Feature request: Show parent directory in a split

### DIFF
--- a/lua/oil/config.lua
+++ b/lua/oil/config.lua
@@ -129,6 +129,7 @@ local default_config = {
     },
     -- preview_split: Split direction: "auto", "left", "right", "above", "below".
     preview_split = "auto",
+	parent_dir_split = "left",
     -- This is the config that will be passed to nvim_open_win.
     -- Change values here to customize the layout
     override = function(conf)

--- a/lua/oil/util.lua
+++ b/lua/oil/util.lua
@@ -667,6 +667,18 @@ M.get_preview_win = function()
   end
 end
 
+---@return nil|integer
+M.get_parent_dir_win = function()
+  for _, winid in ipairs(vim.api.nvim_tabpage_list_wins(0)) do
+    if vim.api.nvim_win_is_valid(winid) then
+      local success, value = pcall(vim.api.nvim_win_get_var, winid, "parentdirwindow")
+      if success and value then
+        return winid
+      end
+    end
+  end
+end
+
 ---@return fun() restore Function that restores the cursor
 M.hide_cursor = function()
   vim.api.nvim_set_hl(0, "OilPreviewCursor", { nocombine = true, blend = 100 })

--- a/lua/oil/view.lua
+++ b/lua/oil/view.lua
@@ -406,6 +406,11 @@ M.initialize = function(bufnr)
       end
 
       constrain_cursor()
+      -- update parent dir window
+      local parent_dir_win_id = util.get_parent_dir_win()
+      if parent_dir_win_id then
+        oil.open_parent_dir()
+      end
 
       if config.preview.update_on_cursor_moved then
         -- Debounce and update the preview window
@@ -695,6 +700,7 @@ M.format_entry_cols = function(entry, column_defs, col_width, adapter)
     local chunk = columns.render_col(adapter, column, entry)
     local text = type(chunk) == "table" and chunk[1] or chunk
     ---@cast text string
+    ---
     col_width[i + 1] = math.max(col_width[i + 1], vim.api.nvim_strwidth(text))
     table.insert(cols, chunk)
   end


### PR DESCRIPTION
This is a proof of concept to show the parent directory in a split next to the oil buffer.

I was inspired by [triptych](https://github.com/simonmclean/triptych.nvim).
Triptych does not have buffer file editing which is why I'm creating this PR.

I don't have the knowledge/time to develop this properly so I wanted to make a POC to at least show what I would like to see added.

![image](https://github.com/user-attachments/assets/e52503d0-8b1f-435f-a91b-caeb617e7bec)
