### PR TITLE
doc: Update links to FreeDesktop's Trash spec

### DIFF
--- a/doc/oil.txt
+++ b/doc/oil.txt
@@ -640,7 +640,7 @@ trash they will be permanently deleted (purged).
 
 Linux:
     Oil supports the FreeDesktop trash specification.
-    https://specifications.freedesktop.org/trash-spec/trashspec-1.0.html
+    https://specifications.freedesktop.org/trash-spec/1.0/
     All features should work.
 
 Mac:

--- a/lua/oil/adapters/trash/freedesktop.lua
+++ b/lua/oil/adapters/trash/freedesktop.lua
@@ -1,5 +1,5 @@
 -- Based on the FreeDesktop.org trash specification
--- https://specifications.freedesktop.org/trash-spec/trashspec-1.0.html
+-- https://specifications.freedesktop.org/trash-spec/1.0/
 local cache = require("oil.cache")
 local config = require("oil.config")
 local constants = require("oil.constants")

--- a/scripts/generate.py
+++ b/scripts/generate.py
@@ -357,7 +357,7 @@ trash they will be permanently deleted (purged).
 
 Linux:
     Oil supports the FreeDesktop trash specification.
-    https://specifications.freedesktop.org/trash-spec/trashspec-1.0.html
+    https://specifications.freedesktop.org/trash-spec/1.0/
     All features should work.
 
 Mac:


### PR DESCRIPTION
Keeping it pinned to `1.0`.

Fixes #489