### PR TITLE
feat: `actions.close` to clear pending motions before closing

### DIFF
--- a/lua/oil/init.lua
+++ b/lua/oil/init.lua
@@ -381,6 +381,14 @@ end
 
 ---Restore the buffer that was present when oil was opened
 M.close = function()
+  local mode = vim.api.nvim_get_mode().mode
+  -- If we're in operator pending or visual modes, we should cancel that operation and return
+  if mode == "no" or mode == "v" or mode == "V" then
+    -- Trigger <ESC> to cancel the operation
+    vim.api.nvim_feedkeys(vim.api.nvim_replace_termcodes("<ESC>", true, true, true), "n", false)
+    return
+  end
+
   -- If we're in a floating oil window, close it and try to restore focus to the original window
   if vim.w.is_oil_win then
     local original_winid = vim.w.oil_original_win


### PR DESCRIPTION
Added extra logic to ensure that `actions.close` doesn't close Oil if we're in `operator pending` or `visual` modes, instead it exits those modes with an `<Esc>` call and returns early.

This is to improve the UX as I can't be the only one who constantly accidentally closes Oil 😅 When all I wanted to do was clear an unfinished motion or get out of visual mode, but stay in Oil.

P.s. Long term Oil user, and loving life with it!
