### PR TITLE
fix: pass opts to actions.preview

### DIFF
--- a/doc/oil.txt
+++ b/doc/oil.txt
@@ -527,6 +527,12 @@ preview                                                          *actions.previe
     Open the entry under the cursor in a preview window, or close the preview
     window if already open
 
+    Parameters:
+      {horizontal} `boolean` Open the buffer in a horizontal split
+      {split}      `"aboveleft"|"belowright"|"topleft"|"botright"` Split
+                   modifier
+      {vertical}   `boolean` Open the buffer in a vertical split
+
 preview_scroll_down                                  *actions.preview_scroll_down*
     Scroll down in the preview window
 

--- a/lua/oil/actions.lua
+++ b/lua/oil/actions.lua
@@ -69,6 +69,20 @@ M.select_tab = {
 
 M.preview = {
   desc = "Open the entry under the cursor in a preview window, or close the preview window if already open",
+  parameters = {
+    vertical = {
+      type = "boolean",
+      desc = "Open the buffer in a vertical split",
+    },
+    horizontal = {
+      type = "boolean",
+      desc = "Open the buffer in a horizontal split",
+    },
+    split = {
+      type = '"aboveleft"|"belowright"|"topleft"|"botright"',
+      desc = "Split modifier",
+    },
+  },
   callback = function(opts)
     local entry = oil.get_cursor_entry()
     if not entry then

--- a/lua/oil/actions.lua
+++ b/lua/oil/actions.lua
@@ -69,7 +69,7 @@ M.select_tab = {
 
 M.preview = {
   desc = "Open the entry under the cursor in a preview window, or close the preview window if already open",
-  callback = function()
+  callback = function(opts)
     local entry = oil.get_cursor_entry()
     if not entry then
       vim.notify("Could not find entry under cursor", vim.log.levels.ERROR)
@@ -88,7 +88,7 @@ M.preview = {
         return
       end
     end
-    oil.open_preview()
+    oil.open_preview(opts)
   end,
 }
 


### PR DESCRIPTION
It looks like an unintened mistake to not pass the opts to the callback, because without it, the preview window cannot be a horizontal split.