### PR TITLE
feat: add trailing slash on yank_entry

### DIFF
--- a/lua/oil/actions.lua
+++ b/lua/oil/actions.lua
@@ -367,8 +367,8 @@ M.yank_entry = {
       return
     end
     local name = entry.name
-    if entry.type == 'directory' then
-      name = name .. '/'
+    if entry.type == "directory" then
+      name = name .. "/"
     end
     local path = dir .. name
     if opts.modify then

--- a/lua/oil/actions.lua
+++ b/lua/oil/actions.lua
@@ -366,7 +366,11 @@ M.yank_entry = {
     if not entry or not dir then
       return
     end
-    local path = dir .. entry.name
+    local name = entry.name
+    if entry.type == 'directory' then
+      name = name .. '/'
+    end
+    local path = dir .. name
     if opts.modify then
       path = vim.fn.fnamemodify(path, opts.modify)
     end


### PR DESCRIPTION
Changed to add a trailing slash if the entry type is directory on yank_entry.

Closes #503
