### PR TITLE
feat: add `win_options` to `preview_win`

### DIFF
--- a/lua/oil/config.lua
+++ b/lua/oil/config.lua
@@ -143,6 +143,8 @@ local default_config = {
     update_on_cursor_moved = true,
     -- Maximum file size in megabytes to preview
     max_file_size_mb = 100,
+    -- Window-local options to use for preview window buffers
+    win_options = {},
   },
   -- Configuration for the floating action confirmation window
   confirmation = {
@@ -326,12 +328,14 @@ local M = {}
 ---@class (exact) oil.PreviewWindowConfig
 ---@field update_on_cursor_moved boolean
 ---@field max_file_size_mb number
+---@field win_options table<string, any>
 
 ---@class (exact) oil.ConfirmationWindowConfig : oil.WindowConfig
 
 ---@class (exact) oil.SetupPreviewWindowConfig
 ---@field update_on_cursor_moved? boolean Whether the preview window is automatically updated when the cursor is moved
 ---@field max_file_size_mb? number Maximum file size in megabytes to preview
+---@field win_options? table<string, any> Window-local options to use for preview window buffers
 
 ---@class (exact) oil.SetupConfirmationWindowConfig : oil.SetupWindowConfig
 

--- a/lua/oil/init.lua
+++ b/lua/oil/init.lua
@@ -551,6 +551,9 @@ M.open_preview = function(opts, callback)
     end
 
     vim.api.nvim_set_option_value("previewwindow", true, { scope = "local", win = 0 })
+    for k, v in pairs(config.preview_win.win_options) do
+      vim.api.nvim_set_option_value(k, v, { scope = "local", win = preview_win })
+    end
     vim.w.oil_entry_id = entry.id
     vim.w.oil_source_win = prev_win
     if is_visual_mode then

--- a/lua/oil/view.lua
+++ b/lua/oil/view.lua
@@ -182,6 +182,11 @@ M.set_win_options = function()
   for k, v in pairs(config.win_options) do
     vim.api.nvim_set_option_value(k, v, { scope = "local", win = winid })
   end
+  if vim.wo[winid].previewwindow then -- apply preview window options last
+    for k, v in pairs(config.preview_win.win_options) do
+      vim.api.nvim_set_option_value(k, v, { scope = "local", win = winid })
+    end
+  end
 end
 
 ---Get a list of visible oil buffers and a list of hidden oil buffers


### PR DESCRIPTION
This adds the ability to customize the window options for the preview window for files/directories. This takes a very basic approach, outside of just adding the `win_options` field to the lua type annotations it makes sure to set the `win_options` when creating the `previewwindow` windows. The other wrinkle it accounts for is to make sure to apply the `preview_win.win_options` after applying oil `win_options` if it's within a `previewwindow`. This makes sure it gets the necessary settings such as `conceal` and `concealcursor` while also applying the settings that the user wants for preview windows.

Let me know what you think of this approach!

Resolves #509 