### PR TITLE
fix: improper file name escaping

### DIFF
--- a/lua/oil/util.lua
+++ b/lua/oil/util.lua
@@ -21,7 +21,7 @@ end
 ---@param filename string
 ---@return string
 M.escape_filename = function(filename)
-  local ret = filename:gsub("([%%#$])", "\\%1")
+  local ret = vim.fn.fnameescape(filename)
   return ret
 end
 


### PR DESCRIPTION
Changes the util file escape function to use the builtin `fnameescape` instead which fixes #529.