### PR TITLE
Fix: filename with newline

### DIFF
--- a/lua/oil/view.lua
+++ b/lua/oil/view.lua
@@ -663,6 +663,10 @@ local function render_buffer(bufnr, opts)
   end
 
   local lines, highlights = util.render_table(line_table, col_width)
+  for k, v in pairs(lines) do
+    --maybe replace it for something else
+    lines[k] = v:gsub("\n", " ")
+  end
 
   vim.bo[bufnr].modifiable = true
   vim.api.nvim_buf_set_lines(bufnr, 0, -1, true, lines)


### PR DESCRIPTION
 If a file has a newline character in a filename for unknown reason (in my case turns out bun $().text() returns a new line) oil would crash, this should fix the issue, I am not really familiar with the codebase, so I'm not really sure if that is the best way to apply the change, so I'm open to any feedback 