### PR TITLE
Add config key to set the file creation permissions

### DIFF
--- a/doc/oil.txt
+++ b/doc/oil.txt
@@ -10,6 +10,7 @@ CONTENTS                                                            *oil-content
   5. Actions                                                     |oil-actions|
   6. Highlights                                               |oil-highlights|
   7. Trash                                                         |oil-trash|
+  8. File Creation                                         |oil-file_creation|
 
 --------------------------------------------------------------------------------
 CONFIG                                                                *oil-config*
@@ -45,6 +46,8 @@ CONFIG                                                                *oil-confi
       },
       -- Send deleted files to the trash instead of permanently deleting them (:help oil-trash)
       delete_to_trash = false,
+      -- Set the default mode to create files (:help oil-file_creation)
+      create_files_mode = 420,
       -- Skip the confirmation popup for simple operations (:help oil.skip_confirm_for_simple_edits)
       skip_confirm_for_simple_edits = false,
       -- Selecting a new/moved/renamed file or directory will prompt you to save changes first
@@ -713,6 +716,36 @@ Mac:
 
 Windows:
     Oil supports the Windows Recycle Bin. All features should work.
+
+--------------------------------------------------------------------------------
+FILE CREATION                                                  *oil-file_creation*
+
+
+Oil defines `create_files_mode` to set the permission for new files. The mode
+follows the Posix numeric standard which use octal notation (base-8), however
+the variable must be set in decimal.
+
+    00700 user (file owner) has read, write, and execute permission
+    00400 user has read permission
+    00200 user has write permission
+    00100 user has execute permission
+    00070 group has read, write, and execute permission
+    00040 group has read permission
+    00020 group has write permission
+    00010 group has execute permission
+    00007 others have read, write, and execute permission
+    00004 others have read permission
+    00002 others have write permission
+    00001 others have execute permission
+    (from the open (2) man pages)
+
+An easy way to provide the right value for `create_files_mode` is using
+`tonumber(e [, base])` function with `base = 8`, for example:
+>lua
+    create_files_mode = tonumber("0644", 8)
+
+The default value is 420 in decimal or 0644 in octal
+
 
 ================================================================================
 vim:tw=80:ts=2:ft=help:norl:syntax=help:

--- a/lua/oil/adapters/files.lua
+++ b/lua/oil/adapters/files.lua
@@ -550,7 +550,7 @@ M.perform_action = function(action, cb)
       ---@diagnostic disable-next-line: param-type-mismatch
       uv.fs_symlink(target, path, flags, cb)
     else
-      fs.touch(path, cb)
+      fs.touch(path, config.file_mode, cb)
     end
   elseif action.type == "delete" then
     local _, path = util.parse_url(action.url)

--- a/lua/oil/adapters/trash/mac.lua
+++ b/lua/oil/adapters/trash/mac.lua
@@ -166,7 +166,7 @@ M.perform_action = function(action, cb)
       ---@diagnostic disable-next-line: param-type-mismatch
       uv.fs_symlink(target, path, flags, cb)
     else
-      fs.touch(path, cb)
+      fs.touch(path, config.file_mode, cb)
     end
   elseif action.type == "delete" then
     local _, path = util.parse_url(action.url)

--- a/lua/oil/config.lua
+++ b/lua/oil/config.lua
@@ -28,6 +28,8 @@ local default_config = {
   },
   -- Send deleted files to the trash instead of permanently deleting them (:help oil-trash)
   delete_to_trash = false,
+  -- Set the default mode to create files (:help oil-file_creation)
+  create_files_mode = 420,
   -- Skip the confirmation popup for simple operations (:help oil.skip_confirm_for_simple_edits)
   skip_confirm_for_simple_edits = false,
   -- Selecting a new/moved/renamed file or directory will prompt you to save changes first
@@ -223,6 +225,7 @@ default_config.view_options.highlight_filename = nil
 ---@field buf_options table<string, any>
 ---@field win_options table<string, any>
 ---@field delete_to_trash boolean
+---@field create_files_mode integer
 ---@field skip_confirm_for_simple_edits boolean
 ---@field prompt_save_on_select_new_entry boolean
 ---@field cleanup_delay_ms integer
@@ -251,6 +254,7 @@ local M = {}
 ---@field buf_options? table<string, any> Buffer-local options to use for oil buffers
 ---@field win_options? table<string, any> Window-local options to use for oil buffers
 ---@field delete_to_trash? boolean Send deleted files to the trash instead of permanently deleting them (:help oil-trash).
+---@field create_files_mode? integer Set the default mode to create files (:help oil-file_creation)
 ---@field skip_confirm_for_simple_edits? boolean Skip the confirmation popup for simple operations (:help oil.skip_confirm_for_simple_edits).
 ---@field prompt_save_on_select_new_entry? boolean Selecting a new/moved/renamed file or directory will prompt you to save changes first (:help prompt_save_on_select_new_entry).
 ---@field cleanup_delay_ms? integer Oil will automatically delete hidden buffers after this delay. You can set the delay to false to disable cleanup entirely. Note that the cleanup process only starts when none of the oil buffers are currently displayed.
@@ -408,6 +412,8 @@ M.setup = function(opts)
   if opts.preview and not opts.confirmation then
     new_conf.confirmation = vim.tbl_deep_extend("keep", opts.preview, default_config.confirmation)
   end
+
+  M.file_mode = opts.create_files_mode
   -- Backwards compatibility. We renamed the 'preview' config to 'preview_win'
   if opts.preview and opts.preview.update_on_cursor_moved ~= nil then
     new_conf.preview_win.update_on_cursor_moved = opts.preview.update_on_cursor_moved

--- a/lua/oil/fs.lua
+++ b/lua/oil/fs.lua
@@ -36,9 +36,10 @@ M.abspath = function(path)
 end
 
 ---@param path string
+---@param mode integer mode to open file (octal)
 ---@param cb fun(err: nil|string)
-M.touch = function(path, cb)
-  uv.fs_open(path, "a", 420, function(err, fd) -- 0644
+M.touch = function(path, mode, cb)
+  uv.fs_open(path, "a", mode, function(err, fd)
     if err then
       cb(err)
     else


### PR DESCRIPTION
This PR defines a new config key called `create_files_mode` to set the default permission used when a file is created.
Currently, Oil uses 644 (420 in decimal) but, at least on Linux most of the tools like (n)vim, touch, or even a simple `> filename` by default uses 664 (436 decimal) so, with this option the user is able to set the default value.