### PR TITLE
Fix: Resolve 'attempt to index local 'meta' (a nil value)'

### DIFF
--- a/lua/oil/columns.lua
+++ b/lua/oil/columns.lua
@@ -69,6 +69,11 @@ M.render_col = function(adapter, col_def, entry)
     return EMPTY
   end
 
+  local meta = entry[FIELD_META]
+  if not meta then
+    return EMPTY
+  end
+
   local chunk = column.render(entry, conf)
   if type(chunk) == "table" then
     if chunk[1]:match("^%s*$") then


### PR DESCRIPTION
After the changes on the commit 1f7da07, when adding more information on the column and having the option to show hidden files set to true, for example:

```lua
require("oil").setup({
    view_options = {
        show_hidden = true,
    },

    columns = {
        "size",
    },
})
```
When open nvim I get an error: `attempt to index local 'meta' (a nil value)` on the file 'files.lua', line 59

I changed the file 'columns.lua' and add the code:
```lua
  local meta = entry[FIELD_META]
  if not meta then
    return EMPTY
  end
```
to check if entry[FIELD_META] is nil, and if it is return EMPTY.

I don't know if is the best solution, but the changes seems to fix the issue.