### PR TITLE
Fix custom directory highlights

### DIFF
--- a/lua/oil/view.lua
+++ b/lua/oil/view.lua
@@ -770,6 +770,10 @@ M.format_entry_cols = function(entry, column_defs, col_width, adapter, is_hidden
     else
       local hl = get_custom_hl(external_entry, is_hidden, false, false)
       if hl then
+        -- Add the trailing / if this is a directory, this is important
+        if entry_type == "directory" then
+          name = name .. "/"
+        end
         table.insert(cols, { name, hl })
         return cols
       end


### PR DESCRIPTION
This PR fixes an issue with custom highlights on directories.

Currently, the custom highlights apply as requested, but remove the trailing '/', causing Oil to consider the directories as deleted and files with the same name as directories to be created.

Simple fix checks if the type is a directory and adds the '/' back