### PR TITLE
Add support for bufnr in custom highlights

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,7 +233,8 @@ require("oil").setup({
       { "name", "asc" },
     },
     -- Customize the highlight group for the file name
-    highlight_filename = function(entry, is_hidden, is_link_target, is_link_orphan)
+    highlight_filename = function(entry, is_hidden, is_link_target, is_link_orphan,
+      bufnr)
       return nil
     end,
   },

--- a/doc/oil.txt
+++ b/doc/oil.txt
@@ -118,7 +118,7 @@ CONFIG                                                                *oil-confi
           { "name", "asc" },
         },
         -- Customize the highlight group for the file name
-        highlight_filename = function(entry, is_hidden, is_link_target, is_link_orphan)
+        highlight_filename = function(entry, is_hidden, is_link_target, is_link_orphan, bufnr)
           return nil
         end,
       },

--- a/lua/oil/config.lua
+++ b/lua/oil/config.lua
@@ -286,7 +286,7 @@ local M = {}
 ---@field natural_order boolean|"fast"
 ---@field case_insensitive boolean
 ---@field sort oil.SortSpec[]
----@field highlight_filename? fun(entry: oil.Entry, is_hidden: boolean, is_link_target: boolean, is_link_orphan: boolean): string|nil
+---@field highlight_filename? fun(entry: oil.Entry, is_hidden: boolean, is_link_target: boolean, is_link_orphan: boolean, bufnr: integer): string|nil
 
 ---@class (exact) oil.SetupViewOptions
 ---@field show_hidden? boolean Show files and directories that start with "."

--- a/lua/oil/view.lua
+++ b/lua/oil/view.lua
@@ -644,14 +644,14 @@ local function render_buffer(bufnr, opts)
 
   if M.should_display("..", bufnr) then
     local cols =
-      M.format_entry_cols({ 0, "..", "directory" }, column_defs, col_width, adapter, true)
+      M.format_entry_cols({ 0, "..", "directory" }, column_defs, col_width, adapter, true, bufnr)
     table.insert(line_table, cols)
   end
 
   for _, entry in ipairs(entry_list) do
     local should_display, is_hidden = M.should_display(entry[FIELD_NAME], bufnr)
     if should_display then
-      local cols = M.format_entry_cols(entry, column_defs, col_width, adapter, is_hidden)
+      local cols = M.format_entry_cols(entry, column_defs, col_width, adapter, is_hidden, bufnr)
       table.insert(line_table, cols)
 
       local name = entry[FIELD_NAME]
@@ -723,8 +723,9 @@ end
 ---@param col_width integer[]
 ---@param adapter oil.Adapter
 ---@param is_hidden boolean
+---@param bufnr integer
 ---@return oil.TextChunk[]
-M.format_entry_cols = function(entry, column_defs, col_width, adapter, is_hidden)
+M.format_entry_cols = function(entry, column_defs, col_width, adapter, is_hidden, bufnr)
   local name = entry[FIELD_NAME]
   local meta = entry[FIELD_META]
   local hl_suffix = ""
@@ -760,15 +761,15 @@ M.format_entry_cols = function(entry, column_defs, col_width, adapter, is_hidden
     if entry_type == "link" then
       link_name, link_target = get_link_text(name, meta)
       local is_orphan = not (meta and meta.link_stat)
-      link_name_hl = get_custom_hl(external_entry, is_hidden, false, is_orphan)
+      link_name_hl = get_custom_hl(external_entry, is_hidden, false, is_orphan, bufnr)
 
       if link_target then
-        link_target_hl = get_custom_hl(external_entry, is_hidden, true, is_orphan)
+        link_target_hl = get_custom_hl(external_entry, is_hidden, true, is_orphan, bufnr)
       end
 
       -- intentional fallthrough
     else
-      local hl = get_custom_hl(external_entry, is_hidden, false, false)
+      local hl = get_custom_hl(external_entry, is_hidden, false, false, bufnr)
       if hl then
         table.insert(cols, { name, hl })
         return cols


### PR DESCRIPTION
This PR enables you to determine the full directory path, enabling, for example, HL groups for Git.

Previously this was provided for `is_hidden_file` or `is_always_hidden` but not for `highlight_filename`.

Code changes are simple, since callers of `highlight_filename` always have bufnr anyway.