### PR TITLE
feat: support floating window dimensions as float

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,7 @@ require("oil").setup({
   float = {
     -- Padding around the floating window
     padding = 2,
+    -- max_width and max_height can be integers or a float between 0 and 1 (e.g. 0.4 for 40%)
     max_width = 0,
     max_height = 0,
     border = "rounded",

--- a/doc/oil.txt
+++ b/doc/oil.txt
@@ -141,6 +141,7 @@ CONFIG                                                                *oil-confi
       float = {
         -- Padding around the floating window
         padding = 2,
+        -- max_width and max_height can be integers or a float between 0 and 1 (e.g. 0.4 for 40%)
         max_width = 0,
         max_height = 0,
         border = "rounded",

--- a/lua/oil/config.lua
+++ b/lua/oil/config.lua
@@ -124,6 +124,7 @@ local default_config = {
   float = {
     -- Padding around the floating window
     padding = 2,
+    -- max_width and max_height can be integers or a float between 0 and 1 (e.g. 0.4 for 40%)
     max_width = 0,
     max_height = 0,
     border = "rounded",

--- a/lua/oil/layout.lua
+++ b/lua/oil/layout.lua
@@ -115,11 +115,13 @@ M.get_fullscreen_win_opts = function()
     width = width - 2 -- The border consumes 1 col on each side
   end
   if config.float.max_width > 0 then
-    width = math.min(width, config.float.max_width)
+    local max_width = math.floor(calc_float(config.float.max_width, total_width))
+    width = math.min(width, max_width)
   end
   local height = total_height - 2 * config.float.padding
   if config.float.max_height > 0 then
-    height = math.min(height, config.float.max_height)
+    local max_height = math.floor(calc_float(config.float.max_height, total_height))
+    height = math.min(height, max_height)
   end
   local row = math.floor((total_height - height) / 2)
   local col = math.floor((total_width - width) / 2) - 1 -- adjust for border width


### PR DESCRIPTION
This PR add support for setting `float.max_width` and `float.max_height` to a float between 0 and 1 (e.g. 0.4 for 40%)