### PR TITLE
fix: restore previously focused window when opening file in multiple-split layout with an open preview window

### DIFF
--- a/lua/oil/init.lua
+++ b/lua/oil/init.lua
@@ -709,7 +709,7 @@ M.select = function(opts, callback)
     else
       -- Close floating window before opening a file
       if vim.w.is_oil_win then
-        vim.api.nvim_win_close(0, false)
+        M.close()
       end
     end
 


### PR DESCRIPTION
This PR restores the original window when opening file using the oil floating window. There is an implementation to restore the focused window but only works for the toggle action.