### PR TITLE
Add hint to disable lazy loading in lazy.nvim install

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,9 +39,9 @@ oil.nvim supports all the usual plugin managers
   opts = {},
   -- Optional dependencies
   dependencies = { { "echasnovski/mini.icons", opts = {} } },
-  -- dependencies = { "nvim-tree/nvim-web-devicons" }, -- use if prefer nvim-web-devicons
-  -- Disable lazy loading which can interfere with features like 'default_file_explorer' 
-  -- lazy = false,
+  -- dependencies = { "nvim-tree/nvim-web-devicons" }, -- use if you prefer nvim-web-devicons
+  -- Lazy loading is not recommended because it is very tricky to make it work correctly in all situations.
+  lazy = false,
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ oil.nvim supports all the usual plugin managers
   -- Optional dependencies
   dependencies = { { "echasnovski/mini.icons", opts = {} } },
   -- dependencies = { "nvim-tree/nvim-web-devicons" }, -- use if prefer nvim-web-devicons
+  -- Disable lazy loading which can interfere with features like 'default_file_explorer' 
+  -- lazy = false,
 }
 ```
 


### PR DESCRIPTION
Closes #539
Disabling lazy loading is necessary to set Oil as the default explorer when Neovim is initially opened.
Not 100% sure about the wording.
