### PR TITLE
Add support for bufnr in column rendering functions

### DIFF
--- a/lua/oil/columns.lua
+++ b/lua/oil/columns.lua
@@ -12,7 +12,7 @@ local all_columns = {}
 ---@alias oil.ColumnSpec string|{[1]: string, [string]: any}
 
 ---@class (exact) oil.ColumnDefinition
----@field render fun(entry: oil.InternalEntry, conf: nil|table): nil|oil.TextChunk
+---@field render fun(entry: oil.InternalEntry, conf: nil|table, bufnr: integer): nil|oil.TextChunk
 ---@field parse fun(line: string, conf: nil|table): nil|string, nil|string
 ---@field compare? fun(entry: oil.InternalEntry, parsed_value: any): boolean
 ---@field render_action? fun(action: oil.ChangeAction): string
@@ -60,8 +60,9 @@ M.EMPTY = EMPTY
 ---@param adapter oil.Adapter
 ---@param col_def oil.ColumnSpec
 ---@param entry oil.InternalEntry
+---@param bufnr integer
 ---@return oil.TextChunk
-M.render_col = function(adapter, col_def, entry)
+M.render_col = function(adapter, col_def, entry, bufnr)
   local name, conf = util.split_config(col_def)
   local column = M.get_column(adapter, name)
   if not column then
@@ -69,7 +70,7 @@ M.render_col = function(adapter, col_def, entry)
     return EMPTY
   end
 
-  local chunk = column.render(entry, conf)
+  local chunk = column.render(entry, conf, bufnr)
   if type(chunk) == "table" then
     if chunk[1]:match("^%s*$") then
       return EMPTY

--- a/lua/oil/view.lua
+++ b/lua/oil/view.lua
@@ -747,7 +747,7 @@ M.format_entry_cols = function(entry, column_defs, col_width, adapter, is_hidden
   table.insert(cols, id_key)
   -- Then add all the configured columns
   for i, column in ipairs(column_defs) do
-    local chunk = columns.render_col(adapter, column, entry)
+    local chunk = columns.render_col(adapter, column, entry, bufnr)
     local text = type(chunk) == "table" and chunk[1] or chunk
     ---@cast text string
     col_width[i + 1] = math.max(col_width[i + 1], vim.api.nvim_strwidth(text))


### PR DESCRIPTION
This is primarily for user-defined custom columns, which may want access to the current path or similar information. The change is relatively simple since bufnr is necessarily always available when rendering columns, and will not break any consumers