### PR TITLE
fix bug of disable_preview

### DIFF
--- a/lua/oil/init.lua
+++ b/lua/oil/init.lua
@@ -560,6 +560,7 @@ M.open_preview = function(opts, callback)
       entry_is_file
       and config.preview_win.preview_method ~= "load"
       and not util.file_matches_bufreadcmd(normalized_url)
+      and not config.preview_win.disable_preview(normalized_url)
     then
       filebufnr =
         util.read_file_to_scratch_buffer(normalized_url, config.preview_win.preview_method)


### PR DESCRIPTION
When open the preview,the preview is very lag,even though `disable_preview` is set.This is because the bug in the [code](https://github.com/stevearc/oil.nvim/blob/add50252b5e9147c0a09d36480d418c7e2737472/lua/oil/init.lua#L559) that `disable_preview` is not used in the `if` statement.

```lua
    if
      entry_is_file
      and config.preview_win.preview_method ~= "load"
      and not util.file_matches_bufreadcmd(normalized_url)
      and not config.preview_win.disable_preview(normalized_url)
    then
      filebufnr =
        util.read_file_to_scratch_buffer(normalized_url, config.preview_win.preview_method)

```