### PR TITLE
fix: prevent E565 error when opening directories with nvim .

### DIFF
--- a/lua/oil/util.lua
+++ b/lua/oil/util.lua
@@ -174,8 +174,10 @@ M.rename_buffer = function(src_bufnr, dest_buf_name)
     -- This will fail if the dest buf name already exists
     local ok = pcall(vim.api.nvim_buf_set_name, src_bufnr, dest_buf_name)
     if ok then
-      -- Renaming the buffer creates a new buffer with the old name. Find it and delete it.
-      vim.api.nvim_buf_delete(vim.fn.bufadd(bufname), {})
+      -- Renaming the buffer creates a new buffer with the old name.
+      -- Find it and try to delete it, but don't if the buffer is in a context
+      -- where Neovim doesn't allow buffer modifications.
+      pcall(vim.api.nvim_buf_delete, vim.fn.bufadd(bufname), {})
       if altbuf and vim.api.nvim_buf_is_valid(altbuf) then
         vim.fn.setreg("#", altbuf)
       end


### PR DESCRIPTION
# Fix E565 error when opening directories with `nvim .`

Neovim version: **v0.12.0-dev-42+ge87d2ae383**

## Stack trace
```
Failed to run 'config' for oil.nvim
... ~/.local/share/nvim/lazy/oil.nvim/lua/oil/util.lua:178: E565: Not allowed to change text or change window
* stacktrace:
- /oil.nvim/lua/oil/util.lua:178 _in_ **rename_buffer**
- /oil.nvim/lua/oil/init.lua:812 _in_ **maybe_hijack_directory_buffer**
- /oil.nvim/lua/oil/init.lua:1396 _in_ **setup**
- ~/ config/nvim/lua/tt/_plugins/oil.lua:18_in_ **setup**
- ~/. config/nvim/lua/tt/plugins.lua:575 _in_ **config**
```
## Description
This PR fixes an issue where oil.nvim throws an error (`E565: Not allowed to change text or change window`) when Neovim is started with a directory argument (e.g., `nvim .`). 

The error occurs because during initialization, the plugin attempts to delete buffers in a context where Neovim doesn't allow buffer modifications. This fix wraps the buffer deletion operations in `pcall()` to safely handle these restrictions.

## Steps to reproduce
1. Lua config:
```lua
        config = function()
            require("oil").setup()

            vim.keymap.set("n", "<leader>e", function()
                require("oil").open()
            end, { desc = "Open Oil file explorer" })
        end
```
2. Navigate to any directory in your terminal
3. Run `nvim .`
4. Hit `<leader>e`
5. Observe the error message in oil's loading process

## Changes
- Added `pcall()` around buffer deletion operations in `rename_buffer` function
   - This allows the function to continue execution even when buffer deletion fails and ensures oil opens the correct directory