### PR TITLE
feat: add file/directory owner and group column

### DIFF
--- a/lua/oil/adapters/files.lua
+++ b/lua/oil/adapters/files.lua
@@ -58,6 +58,9 @@ file_columns.ownership = {
   render = function (entry, _, _)
     local meta = entry[FIELD_META]
     local stat = meta and meta.stat
+    if not stat then
+      return columns.EMPTY
+    end
     local user = passwd.passwd_entries[stat.uid]
     local group = passwd.group_entries[stat.gid]
     if user ~= nil and group ~= nil then

--- a/lua/oil/init.lua
+++ b/lua/oil/init.lua
@@ -1113,9 +1113,13 @@ local _on_key_ns = 0
 M.setup = function(opts)
   local Ringbuf = require("oil.ringbuf")
   local config = require("oil.config")
+  local passwd = require('oil.passwd')
 
   config.setup(opts)
   set_colors()
+  passwd.parse_passwd()
+  passwd.parse_groups()
+
   vim.api.nvim_create_user_command("Oil", function(args)
     local util = require("oil.util")
     if args.smods.tab == 1 then

--- a/lua/oil/passwd.lua
+++ b/lua/oil/passwd.lua
@@ -5,6 +5,8 @@ local M = {}
 ---@field uid integer
 ---@field gid integer
 
+-- XXX: we need to do both username->uid and uid->username lookups
+-- so maybe restructure this table to be more efficient...
 ---@type {[integer]: PasswdEntry}
 M.passwd_entries = {}
 
@@ -54,6 +56,28 @@ M.parse_groups = function()
     end
     ::continue::
   end
+end
+
+---@param username string
+---@return integer?
+M.uid_from_username = function(username)
+  for uid, fields in pairs(M.passwd_entries) do
+    if fields.username == username then
+      return uid
+    end
+  end
+  return nil
+end
+
+---@param groupname string
+---@return integer?
+M.gid_from_groupname = function(groupname)
+  for gid, fields in pairs(M.group_entries) do
+    if fields.name == groupname then
+      return gid
+    end
+  end
+  return nil
 end
 
 return M

--- a/lua/oil/passwd.lua
+++ b/lua/oil/passwd.lua
@@ -1,0 +1,59 @@
+local M = {}
+
+---@class PasswdEntry
+---@field username string
+---@field uid integer
+---@field gid integer
+
+---@type {[integer]: PasswdEntry}
+M.passwd_entries = {}
+
+---@class GroupEntry
+---@field name string
+---@field gid integer
+
+---@type {[integer]: GroupEntry}
+M.group_entries = {}
+
+-- TODO use async uv io
+
+M.parse_passwd = function()
+  local entry_pat = [[\v^([a-zA-Z0-9-_\.]+):[^:]+:(\d+):(\d+):%([^:]+)?:[^:]+:[^:]+$]]
+  for entry in io.lines('/etc/passwd') do
+    local m = vim.fn.matchlist(entry, entry_pat)
+    if m == nil then -- invalid entry, skip
+      goto continue
+    end
+
+    local uid, gid = tonumber(m[3]), tonumber(m[4])
+    if uid ~= nil and gid ~= nil then
+      M.passwd_entries[uid] = {
+        username = m[2],
+        uid = uid,
+        gid = gid,
+      }
+    end
+    ::continue::
+  end
+end
+
+M.parse_groups = function()
+  local entry_pat = [[\v^([a-zA-Z0-9-_\.]+):%([^:]+)?:(\d+):%([^:]+)?$]]
+  for entry in io.lines('/etc/group') do
+    local m = vim.fn.matchlist(entry, entry_pat)
+    if m == nil then
+      goto continue
+    end
+
+    local gid = tonumber(m[3])
+    if gid ~= nil then
+      M.group_entries[gid] = {
+        name = m[2],
+        gid = gid,
+      }
+    end
+    ::continue::
+  end
+end
+
+return M


### PR DESCRIPTION
For now it can only display it. I will keep working on it to support modifying the owner and group. For this we parse the `/etc/passwd` and `/etc/group` files, so it is UNIX only, although it also may not work on some unix-like systems, like Android on Termux, for instance so I wonder how could I deal with that.

closes #436, closes #599 