### PR TITLE
fix: using select tab will create extra a blank buffer.

### DIFF
--- a/lua/oil/init.lua
+++ b/lua/oil/init.lua
@@ -749,21 +749,23 @@ M.select = function(opts, callback)
         vim.bo[filebufnr].buflisted = true
       end
 
-      local cmd = "buffer"
       if opts.tab then
-        vim.cmd.tabnew({ mods = mods })
-      elseif opts.split then
-        cmd = "sbuffer"
-      end
-      ---@diagnostic disable-next-line: param-type-mismatch
-      local ok, err = pcall(vim.cmd, {
-        cmd = cmd,
-        args = { filebufnr },
-        mods = mods,
-      })
-      -- Ignore swapfile errors
-      if not ok and err and not err:match("^Vim:E325:") then
-        vim.api.nvim_echo({ { err, "Error" } }, true, {})
+        vim.cmd.tabnew({ args = { "#"..filebufnr },  mods = mods })
+      else
+        local cmd = "buffer"
+        if opts.split then
+          cmd = "sbuffer"
+        end
+        ---@diagnostic disable-next-line: param-type-mismatch
+        local ok, err = pcall(vim.cmd, {
+          cmd = cmd,
+          args = { filebufnr },
+          mods = mods,
+        })
+        -- Ignore swapfile errors
+        if not ok and err and not err:match("^Vim:E325:") then
+          vim.api.nvim_echo({ { err, "Error" } }, true, {})
+        end
       end
 
       open_next_entry(cb)


### PR DESCRIPTION
Problem
---
When using action.select.opts.tab to open a file, an extra blank buffer is created.

This blank buffer comes from the command `tabnew`, the command will create a blank buffer and empty window, but action.select.opts.tab just to using empty window, does not to using this blank buffer.

https://github.com/stevearc/oil.nvim/blob/302bbaceeafc690e6419e0c8296e804d60cb9446/lua/oil/init.lua#L743-L763

Reproduction
---
```bash
$ nvim --version
NVIM v0.11.0
Build type: None
LuaJIT 2.1.1736781742
Run "nvim -V1 -v" for more info
```
Typing `:Oil<CR><C-t>`
![image](https://github.com/user-attachments/assets/302a1f0e-8f31-4c98-9534-f4c86496b85a)

How to fix
---
`tabnew` has the same properties like `edit`, so you can just open a buffer directly like `edit #<bufnr>`.

```doc
:[count]tabnew [++opt] [+cmd] {file}
		Open a new tab page and edit {file}, like with |:edit|.
		For [count] see |:tabnew| above.
```
```doc
							*:edit_#* *:e#*
:e[dit] [++opt] [+cmd] #[count]
			Edit the [count]th buffer (as shown by |:files|).
			This command does the same as [count] CTRL-^.  But ":e
			#" doesn't work if the alternate buffer doesn't have a
			file name, while CTRL-^ still works then.
			Also see |++opt| and |+cmd|.
```
Typing `:Oil<CR><C-t>`
![image](https://github.com/user-attachments/assets/722ff3d0-b75e-4bda-b90b-51f200f90230)