### PR TITLE
fix: add iso8601 format compatibility

### DIFF
--- a/lua/oil/adapters/ssh/sshfs.lua
+++ b/lua/oil/adapters/ssh/sshfs.lua
@@ -42,10 +42,16 @@ local function parse_ls_line(line)
   local name, size, date, major, minor
   if typechar == "c" or typechar == "b" then
     major, minor, date, name = rem:match("^(%d+)%s*,%s*(%d+)%s+(%S+%s+%d+%s+%d%d:?%d%d)%s+(.*)")
+    if name == nil then
+      major, minor, date, name = rem:match("^(%d+)%s*,%s*(%d+)%s+(%d+%-%d+%-%d+%s+%d%d:?%d%d)%s+(.*)")
+    end
     meta.major = tonumber(major)
     meta.minor = tonumber(minor)
   else
     size, date, name = rem:match("^(%d+)%s+(%S+%s+%d+%s+%d%d:?%d%d)%s+(.*)")
+    if name == nil then
+      size, date, name = rem:match("^(%d+)%s+(%d+%-%d+%-%d+%s+%d%d:?%d%d)%s+(.*)")
+    end
     meta.size = tonumber(size)
   end
   meta.iso_modified_date = date

--- a/lua/oil/adapters/ssh/sshfs.lua
+++ b/lua/oil/adapters/ssh/sshfs.lua
@@ -43,7 +43,8 @@ local function parse_ls_line(line)
   if typechar == "c" or typechar == "b" then
     major, minor, date, name = rem:match("^(%d+)%s*,%s*(%d+)%s+(%S+%s+%d+%s+%d%d:?%d%d)%s+(.*)")
     if name == nil then
-      major, minor, date, name = rem:match("^(%d+)%s*,%s*(%d+)%s+(%d+%-%d+%-%d+%s+%d%d:?%d%d)%s+(.*)")
+      major, minor, date, name =
+        rem:match("^(%d+)%s*,%s*(%d+)%s+(%d+%-%d+%-%d+%s+%d%d:?%d%d)%s+(.*)")
     end
     meta.major = tonumber(major)
     meta.minor = tonumber(minor)


### PR DESCRIPTION
fixes https://github.com/stevearc/oil.nvim/issues/634, fallback to match the `iso8601` format