### PR TITLE
doc: add a mention to third party extension oil-git.nvim

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,6 +366,7 @@ Note that at the moment the ssh adapter does not support Windows machines, and i
 These are plugins maintained by other authors that extend the functionality of oil.nvim.
 
 - [oil-git-status.nvim](https://github.com/refractalize/oil-git-status.nvim) - Shows git status of files in statuscolumn
+- [oil-git.nvim](https://github.com/benomahony/oil-git.nvim) - Shows git status of files with colour and symbols
 - [oil-lsp-diagnostics.nvim](https://github.com/JezerM/oil-lsp-diagnostics.nvim) - Shows LSP diagnostics indicator as virtual text
 
 ## API


### PR DESCRIPTION
Adding a mention of another 3rd party extension for colouring the filenames in the oil buffer based on git status
<img width="260" alt="Screenshot 2025-07-01 at 09 59 20" src="https://github.com/user-attachments/assets/99bdc6ce-9778-4a3c-93d3-5d1f5638c0a1" />
