### PR TITLE
feat: pass entry to is_hidden_file and is_always_hidden

### DIFF
--- a/lua/oil/config.lua
+++ b/lua/oil/config.lua
@@ -282,8 +282,8 @@ local M = {}
 
 ---@class (exact) oil.ViewOptions
 ---@field show_hidden boolean
----@field is_hidden_file fun(name: string, bufnr: integer): boolean
----@field is_always_hidden fun(name: string, bufnr: integer): boolean
+---@field is_hidden_file fun(name: string, bufnr: integer, entry: oil.Entry): boolean
+---@field is_always_hidden fun(name: string, bufnr: integer, entry: oil.Entry): boolean
 ---@field natural_order boolean|"fast"
 ---@field case_insensitive boolean
 ---@field sort oil.SortSpec[]

--- a/lua/oil/init.lua
+++ b/lua/oil/init.lua
@@ -129,7 +129,7 @@ M.set_sort = function(sort)
 end
 
 ---Change how oil determines if the file is hidden
----@param is_hidden_file fun(filename: string, bufnr: integer): boolean Return true if the file/dir should be hidden
+---@param is_hidden_file fun(filename: string, bufnr: integer, entry: oil.Entry): boolean Return true if the file/dir should be hidden
 M.set_is_hidden_file = function(is_hidden_file)
   require("oil.view").set_is_hidden_file(is_hidden_file)
 end

--- a/lua/oil/mutator/parser.lua
+++ b/lua/oil/mutator/parser.lua
@@ -176,7 +176,7 @@ M.parse = function(bufnr)
   local original_entries = {}
   for _, child in pairs(children) do
     local name = child[FIELD_NAME]
-    if view.should_display(name, bufnr) then
+    if view.should_display(bufnr, child) then
       original_entries[name] = child[FIELD_ID]
     end
   end

--- a/lua/oil/view.lua
+++ b/lua/oil/view.lua
@@ -17,15 +17,17 @@ local FIELD_META = constants.FIELD_META
 -- map of path->last entry under cursor
 local last_cursor_entry = {}
 
----@param name string
 ---@param bufnr integer
+---@param entry oil.InternalEntry
 ---@return boolean display
 ---@return boolean is_hidden Whether the file is classified as a hidden file
-M.should_display = function(name, bufnr)
-  if config.view_options.is_always_hidden(name, bufnr) then
+M.should_display = function(bufnr, entry)
+  local name = entry[FIELD_NAME]
+  local public_entry = util.export_entry(entry)
+  if config.view_options.is_always_hidden(name, bufnr, public_entry) then
     return false, true
   else
-    local is_hidden = config.view_options.is_hidden_file(name, bufnr)
+    local is_hidden = config.view_options.is_hidden_file(name, bufnr, public_entry)
     local display = config.view_options.show_hidden or not is_hidden
     return display, is_hidden
   end
@@ -85,7 +87,7 @@ M.toggle_hidden = function()
   end
 end
 
----@param is_hidden_file fun(filename: string, bufnr: integer): boolean
+---@param is_hidden_file fun(filename: string, bufnr: integer, entry: oil.Entry): boolean
 M.set_is_hidden_file = function(is_hidden_file)
   local any_modified = are_any_modified()
   if any_modified then
@@ -645,14 +647,15 @@ local function render_buffer(bufnr, opts)
     col_width[i + 1] = 1
   end
 
-  if M.should_display("..", bufnr) then
+  local parent_entry = { 0, "..", "directory" }
+  if M.should_display(bufnr, parent_entry) then
     local cols =
-      M.format_entry_cols({ 0, "..", "directory" }, column_defs, col_width, adapter, true, bufnr)
+      M.format_entry_cols(parent_entry, column_defs, col_width, adapter, true, bufnr)
     table.insert(line_table, cols)
   end
 
   for _, entry in ipairs(entry_list) do
-    local should_display, is_hidden = M.should_display(entry[FIELD_NAME], bufnr)
+    local should_display, is_hidden = M.should_display(bufnr, entry)
     if should_display then
       local cols = M.format_entry_cols(entry, column_defs, col_width, adapter, is_hidden, bufnr)
       table.insert(line_table, cols)


### PR DESCRIPTION
Having the entry available for `is_hidden_file` enables checks such as filtering by type (only show directories, only show symlinks etc.) as well as only showing files a user can actually access (by checking the user and group id for local files for instance).
The same applies to `is_always_hidden`.
Note: I've kept the old `name` parameter, since I don't think breaking existing configs makes sense here.