### PR TITLE
fix: support natural ordering for numbers with >12 digits

### DIFF
--- a/lua/oil/columns.lua
+++ b/lua/oil/columns.lua
@@ -228,8 +228,8 @@ M.register("type", {
   end,
 })
 
-local function pad_number(int)
-  return string.format("%012d", int)
+local function adjust_number(int)
+  return string.format("%03d%s", #int, int)
 end
 
 M.register("name", {
@@ -258,11 +258,11 @@ M.register("name", {
     else
       if config.view_options.case_insensitive then
         return function(entry)
-          return entry[FIELD_NAME]:gsub("%d+", pad_number):lower()
+          return entry[FIELD_NAME]:gsub("0*(%d+)", adjust_number):lower()
         end
       else
         return function(entry)
-          return entry[FIELD_NAME]:gsub("%d+", pad_number)
+          return entry[FIELD_NAME]:gsub("0*(%d+)", adjust_number)
         end
       end
     end

--- a/lua/oil/columns.lua
+++ b/lua/oil/columns.lua
@@ -256,14 +256,16 @@ M.register("name", {
         end
       end
     else
-      if config.view_options.case_insensitive then
-        return function(entry)
-          return entry[FIELD_NAME]:gsub("0*(%d+)", adjust_number):lower()
+      local memo = {}
+      return function(entry)
+        if memo[entry] == nil then
+          local name = entry[FIELD_NAME]:gsub("0*(%d+)", adjust_number)
+          if config.view_options.case_insensitive then
+            name = name:lower()
+          end
+          memo[entry] = name
         end
-      else
-        return function(entry)
-          return entry[FIELD_NAME]:gsub("0*(%d+)", adjust_number)
-        end
+        return memo[entry]
       end
     end
   end,

--- a/lua/oil/view.lua
+++ b/lua/oil/view.lua
@@ -587,7 +587,7 @@ local function get_sort_function(adapter, num_entries)
   end
   return function(a, b)
     for _, sort_fn in ipairs(idx_funs) do
-      local get_sort_value, order = unpack(sort_fn)
+      local get_sort_value, order = sort_fn[1], sort_fn[2]
       local a_val = get_sort_value(a)
       local b_val = get_sort_value(b)
       if a_val ~= b_val then


### PR DESCRIPTION
Changes the column ordering code when `view_options.natural_order` is enabled, so that it can support larger numbers.

I chose to handle numbers of up to 999 digits, because some cursory research seems to suggest to me that most filesystems cap at 255 bytes per segment, and 999 > 255, so it should be sufficient for all actual filenames.

Performance may have changed but I don't know if it will be better or worse.

I've slightly increased the complexity of the `string.format` format specifier, but the final strings will be shorter on average, and `string.format` no longer has to implicitly coerce `int` from a string into a number.

before:
<img width="311" height="638" alt="image" src="https://github.com/user-attachments/assets/bb32ecb2-cfbb-4df2-b9b2-ea33faa8e8ff" />
after:
<img width="311" height="638" alt="image" src="https://github.com/user-attachments/assets/c25d8c49-160a-4399-9fd7-f5512dc8e8e4" />
