### PR TITLE
feat: add oil persistent file explorer recipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,6 +360,7 @@ Note that at the moment the ssh adapter does not support Windows machines, and i
 - [Toggle file detail view](doc/recipes.md#toggle-file-detail-view)
 - [Show CWD in the winbar](doc/recipes.md#show-cwd-in-the-winbar)
 - [Hide gitignored files and show git tracked hidden files](doc/recipes.md#hide-gitignored-files-and-show-git-tracked-hidden-files)
+- [Use oil as a persistent file explorer](doc/recipes.md#use-oil-as-a-persistent-file-explorer)
 
 ## Third-party extensions
 


### PR DESCRIPTION
Adds recipe for using oil as a persisten file explorer...

How it works: We two separate windows: one for oil and another for editing. Once toggled, new buffers loading into the editing window cause the cwd shown by oil to be refreshed. Any new files opened via the oil window/buffer are opened in the editing window. 