### PR TITLE
feat: virtual column headers

### DIFF
--- a/lua/oil/config.lua
+++ b/lua/oil/config.lua
@@ -51,6 +51,8 @@ local default_config = {
   constrain_cursor = "editable",
   -- Set to true to watch the filesystem for changes and reload oil
   watch_for_changes = false,
+  -- Show column headers at the top of the oil buffer using virtual text
+  show_header = false,
   -- Keymaps in oil buffer. Can be any value that `vim.keymap.set` accepts OR a table of keymap
   -- options with a `callback` (e.g. { callback = function() ... end, desc = "", mode = "n" })
   -- Additionally, if it is a string that matches "actions.<name>",
@@ -230,6 +232,7 @@ default_config.view_options.highlight_filename = nil
 ---@field lsp_file_methods oil.LspFileMethods
 ---@field constrain_cursor false|"name"|"editable"
 ---@field watch_for_changes boolean
+---@field show_header boolean
 ---@field keymaps table<string, any>
 ---@field use_default_keymaps boolean
 ---@field view_options oil.ViewOptions
@@ -258,6 +261,7 @@ local M = {}
 ---@field lsp_file_methods? oil.SetupLspFileMethods Configure LSP file operation integration.
 ---@field constrain_cursor? false|"name"|"editable" Constrain the cursor to the editable parts of the oil buffer. Set to `false` to disable, or "name" to keep it on the file names.
 ---@field watch_for_changes? boolean Set to true to watch the filesystem for changes and reload oil.
+---@field show_header? boolean Show column headers at the top of the oil buffer using virtual text.
 ---@field keymaps? table<string, any>
 ---@field use_default_keymaps? boolean Set to false to disable all of the above keymaps
 ---@field view_options? oil.SetupViewOptions Configure which files are shown and how they are shown.

--- a/lua/oil/config.lua
+++ b/lua/oil/config.lua
@@ -53,6 +53,8 @@ local default_config = {
   watch_for_changes = false,
   -- Show column headers at the top of the oil buffer using virtual text
   show_header = false,
+  -- Optional function to format header text for each column
+  header_format = nil,
   -- Keymaps in oil buffer. Can be any value that `vim.keymap.set` accepts OR a table of keymap
   -- options with a `callback` (e.g. { callback = function() ... end, desc = "", mode = "n" })
   -- Additionally, if it is a string that matches "actions.<name>",
@@ -233,6 +235,7 @@ default_config.view_options.highlight_filename = nil
 ---@field constrain_cursor false|"name"|"editable"
 ---@field watch_for_changes boolean
 ---@field show_header boolean
+---@field header_format? fun(header_text: string): string
 ---@field keymaps table<string, any>
 ---@field use_default_keymaps boolean
 ---@field view_options oil.ViewOptions
@@ -262,6 +265,7 @@ local M = {}
 ---@field constrain_cursor? false|"name"|"editable" Constrain the cursor to the editable parts of the oil buffer. Set to `false` to disable, or "name" to keep it on the file names.
 ---@field watch_for_changes? boolean Set to true to watch the filesystem for changes and reload oil.
 ---@field show_header? boolean Show column headers at the top of the oil buffer using virtual text.
+---@field header_format? fun(header_text: string): string Optional function to format header text for each column.
 ---@field keymaps? table<string, any>
 ---@field use_default_keymaps? boolean Set to false to disable all of the above keymaps
 ---@field view_options? oil.SetupViewOptions Configure which files are shown and how they are shown.

--- a/lua/oil/init.lua
+++ b/lua/oil/init.lua
@@ -899,6 +899,11 @@ M._get_highlights = function()
       desc = "Hidden normal files in an oil buffer",
     },
     {
+      name = "OilColumnHeader",
+      link = "Title",
+      desc = "Column headers in an oil buffer",
+    },
+    {
       name = "OilCreate",
       link = "DiagnosticInfo",
       desc = "Create action in the oil preview window",

--- a/lua/oil/view.lua
+++ b/lua/oil/view.lua
@@ -279,6 +279,8 @@ local function constrain_cursor(bufnr, mode)
   if config.show_header and row == 1 then
     row = 2
   end
+  -- TODO: this seems to be flakey. I occasionally get an index out of bounds error
+  -- here but can't figure out how to reliably reproduce it. 
   local line = vim.api.nvim_buf_get_lines(bufnr, row - 1, row, true)[1]
   local column_defs = columns.get_supported_columns(adapter)
   local result = parser.parse_line(adapter, line, column_defs)

--- a/lua/oil/view.lua
+++ b/lua/oil/view.lua
@@ -275,7 +275,11 @@ local function constrain_cursor(bufnr, mode)
   end
 
   local cur = vim.api.nvim_win_get_cursor(0)
-  local line = vim.api.nvim_buf_get_lines(bufnr, cur[1] - 1, cur[1], true)[1]
+  local row = cur[1]
+  if config.show_header and row == 1 then
+    row = 2
+  end
+  local line = vim.api.nvim_buf_get_lines(bufnr, row - 1, row, true)[1]
   local column_defs = columns.get_supported_columns(adapter)
   local result = parser.parse_line(adapter, line, column_defs)
   if result and result.ranges then
@@ -288,7 +292,7 @@ local function constrain_cursor(bufnr, mode)
       error(string.format('Unexpected value "%s" for option constrain_cursor', mode))
     end
     if cur[2] < min_col then
-      vim.api.nvim_win_set_cursor(0, { cur[1], min_col })
+      vim.api.nvim_win_set_cursor(0, { row, min_col })
     end
   end
 end

--- a/lua/oil/view.lua
+++ b/lua/oil/view.lua
@@ -315,6 +315,12 @@ M.render_column_headers = function(bufnr, column_defs, col_width, adapter)
 
     if name ~= "icon" then
       local display_name = name:upper()
+
+      -- Apply header format function if provided
+      if config.header_format then
+        display_name = config.header_format(display_name)
+      end
+
       local padded_text = util.rpad(display_name, width)
       header_line = header_line .. padded_text
     else
@@ -327,7 +333,12 @@ M.render_column_headers = function(bufnr, column_defs, col_width, adapter)
     end
   end
 
-  header_line = header_line .. " NAME"
+  -- Add filename column header
+  local name_header = "NAME"
+  if config.header_format then
+    name_header = config.header_format(name_header)
+  end
+  header_line = header_line .. " " .. name_header
 
   if header_line:match("%S") then
     vim.api.nvim_buf_set_extmark(bufnr, ns, 0, 0, {
@@ -715,6 +726,12 @@ local function render_buffer(bufnr, opts)
       local name = util.split_config(column_def)
       if name ~= "icon" then
         local display_name = name:upper()
+
+        -- Apply header format function if provided
+        if config.header_format then
+          display_name = config.header_format(display_name)
+        end
+
         col_width[i + 1] = math.max(col_width[i + 1], vim.api.nvim_strwidth(display_name))
       end
     end


### PR DESCRIPTION
This adds a couple new optional settings `show_header` and `header_format`. the first is a boolean that turns on a header row displayed with virtual text, and the second is a function that takes each header string and should return a new string for a header display. if the `header_format` function is not set, the upcased column name is used by default.

an basic example config:
```lua
{
  show_header = true,
  header_format = function(header_text)
    if header_text == "MTIME" then
      return "Modified"
    elseif header_text == "CTIME" then
      return "Changed"
    elseif header_text == "ATIME" then
      return "Accessed"
    elseif header_text == "BIRTHTIME" then
      return "Created"
    elseif header_text == "SIZE" then
      return "Size"
    elseif header_text == "NAME" then
      return "Filename"
    else
      return header_text
    end
  end
  -- other options...
}
```