### PR TITLE
[WIP] feat: virtual text columns + headers

### DIFF
--- a/lua/oil/adapters/files.lua
+++ b/lua/oil/adapters/files.lua
@@ -164,6 +164,12 @@ for _, time_key in ipairs({ "ctime", "mtime", "atime", "birthtime" }) do
       local fmt = conf and conf.format
       local ret
       if fmt then
+        if type(fmt) == "function" then
+          if not config.virtual_text_columns then
+            error("Custom format functions for time columns require virtual_text_columns to be enabled")
+          end
+          return fmt(stat[time_key].sec)
+        end
         ret = vim.fn.strftime(fmt, stat[time_key].sec)
       else
         local year = vim.fn.strftime("%Y", stat[time_key].sec)

--- a/lua/oil/clipboard.lua
+++ b/lua/oil/clipboard.lua
@@ -55,7 +55,7 @@ local function paste_paths(paths)
   local bufnr = vim.api.nvim_get_current_buf()
   local scheme = "oil://"
   local adapter = assert(config.get_adapter_by_scheme(scheme))
-  local column_defs = columns.get_supported_columns(scheme)
+  local column_defs = columns.get_editable_columns(scheme)
   local winid = vim.api.nvim_get_current_win()
 
   local parent_urls = {}

--- a/lua/oil/columns.lua
+++ b/lua/oil/columns.lua
@@ -57,7 +57,6 @@ local EMPTY = { "-", "Comment" }
 
 M.EMPTY = EMPTY
 
----Check if a column is editable (has perform_action function)
 ---@param adapter oil.Adapter
 ---@param defn oil.ColumnSpec
 ---@return boolean
@@ -69,7 +68,7 @@ M.is_editable_column = function(adapter, defn)
   return column and column.perform_action ~= nil
 end
 
----Get only the editable columns (those with perform_action)
+---Get all editable columns (identical to get_supported_columns when virtual_text_columns is false)
 ---@param adapter_or_scheme string|oil.Adapter
 ---@return oil.ColumnSpec[]
 M.get_editable_columns = function(adapter_or_scheme)

--- a/lua/oil/columns.lua
+++ b/lua/oil/columns.lua
@@ -57,6 +57,41 @@ local EMPTY = { "-", "Comment" }
 
 M.EMPTY = EMPTY
 
+---Check if a column is editable (has perform_action function)
+---@param adapter oil.Adapter
+---@param defn oil.ColumnSpec
+---@return boolean
+M.is_editable_column = function(adapter, defn)
+  if defn == "name" then
+    return true
+  end
+  local column = M.get_column(adapter, defn)
+  return column and column.perform_action ~= nil
+end
+
+---Get only the editable columns (those with perform_action)
+---@param adapter_or_scheme string|oil.Adapter
+---@return oil.ColumnSpec[]
+M.get_editable_columns = function(adapter_or_scheme)
+  if not config.virtual_text_columns then
+    return M.get_supported_columns(adapter_or_scheme)
+  end
+  local adapter
+  if type(adapter_or_scheme) == "string" then
+    adapter = config.get_adapter_by_scheme(adapter_or_scheme)
+  else
+    adapter = adapter_or_scheme
+  end
+  assert(adapter)
+  local ret = {}
+  for _, def in ipairs(config.columns) do
+    if M.get_column(adapter, def) and M.is_editable_column(adapter, def) then
+      table.insert(ret, def)
+    end
+  end
+  return ret
+end
+
 ---@param adapter oil.Adapter
 ---@param col_def oil.ColumnSpec
 ---@param entry oil.InternalEntry

--- a/lua/oil/config.lua
+++ b/lua/oil/config.lua
@@ -14,6 +14,11 @@ local default_config = {
   -- When enabled, the name column can optionally be added to columns config
   -- though it is still required to be the last MUTABLE column
   virtual_text_columns = false,
+  -- Show column headers above the file list
+  show_header = false,
+  -- Optional function to customize header text
+  -- Example: header_format = function(text) return text:lower() end
+  header_format = nil,
   -- Buffer-local options to use for oil buffers
   buf_options = {
     buflisted = false,
@@ -226,6 +231,8 @@ default_config.view_options.highlight_filename = nil
 ---@field default_file_explorer boolean
 ---@field columns oil.ColumnSpec[]
 ---@field virtual_text_columns boolean
+---@field show_header boolean
+---@field header_format? fun(text: string): string
 ---@field buf_options table<string, any>
 ---@field win_options table<string, any>
 ---@field delete_to_trash boolean
@@ -255,6 +262,8 @@ local M = {}
 ---@field default_file_explorer? boolean Oil will take over directory buffers (e.g. `vim .` or `:e src/`). Set to false if you still want to use netrw.
 ---@field columns? oil.ColumnSpec[] The columns to display. See :help oil-columns.
 ---@field virtual_text_columns? boolean If true, then immutable columns will be rendered with virtual text. When this option is on, the name column can be configured in columns config but it must still be the last mutable column.
+---@field show_header? boolean Show column headers above the file list.
+---@field header_format? fun(text: string): string Optional function to customize header text. Example: header_format = function(text) return text:lower() end
 ---@field buf_options? table<string, any> Buffer-local options to use for oil buffers
 ---@field win_options? table<string, any> Window-local options to use for oil buffers
 ---@field delete_to_trash? boolean Send deleted files to the trash instead of permanently deleting them (:help oil-trash).

--- a/lua/oil/config.lua
+++ b/lua/oil/config.lua
@@ -10,6 +10,10 @@ local default_config = {
     -- "size",
     -- "mtime",
   },
+  -- If true, then immutable columns will be rendered with virtual text
+  -- When this option is on, the name column can be configured in column config
+  -- as long as it is still the last mutable column
+  virtual_text_columns = false,
   -- Buffer-local options to use for oil buffers
   buf_options = {
     buflisted = false,
@@ -221,6 +225,7 @@ default_config.view_options.highlight_filename = nil
 ---@field silence_scp_warning? boolean Undocumented option
 ---@field default_file_explorer boolean
 ---@field columns oil.ColumnSpec[]
+---@field virtual_text_columns boolean
 ---@field buf_options table<string, any>
 ---@field win_options table<string, any>
 ---@field delete_to_trash boolean
@@ -249,6 +254,7 @@ local M = {}
 ---@class (exact) oil.SetupOpts
 ---@field default_file_explorer? boolean Oil will take over directory buffers (e.g. `vim .` or `:e src/`). Set to false if you still want to use netrw.
 ---@field columns? oil.ColumnSpec[] The columns to display. See :help oil-columns.
+---@field virtual_text_columns? boolean If true, then immutable columns will be rendered with virtual text. When this option is on, the name column can be configured in column config as long as it is still the last mutable column.
 ---@field buf_options? table<string, any> Buffer-local options to use for oil buffers
 ---@field win_options? table<string, any> Window-local options to use for oil buffers
 ---@field delete_to_trash? boolean Send deleted files to the trash instead of permanently deleting them (:help oil-trash).

--- a/lua/oil/config.lua
+++ b/lua/oil/config.lua
@@ -10,9 +10,9 @@ local default_config = {
     -- "size",
     -- "mtime",
   },
-  -- If true, then immutable columns will be rendered with virtual text
-  -- When this option is on, the name column can be configured in column config
-  -- as long as it is still the last mutable column
+  -- Render immutable columns with virtual text instead of in the buffer
+  -- When enabled, the name column can optionally be added to columns config
+  -- though it is still required to be the last MUTABLE column
   virtual_text_columns = false,
   -- Buffer-local options to use for oil buffers
   buf_options = {
@@ -254,7 +254,7 @@ local M = {}
 ---@class (exact) oil.SetupOpts
 ---@field default_file_explorer? boolean Oil will take over directory buffers (e.g. `vim .` or `:e src/`). Set to false if you still want to use netrw.
 ---@field columns? oil.ColumnSpec[] The columns to display. See :help oil-columns.
----@field virtual_text_columns? boolean If true, then immutable columns will be rendered with virtual text. When this option is on, the name column can be configured in column config as long as it is still the last mutable column.
+---@field virtual_text_columns? boolean If true, then immutable columns will be rendered with virtual text. When this option is on, the name column can be configured in columns config but it must still be the last mutable column.
 ---@field buf_options? table<string, any> Buffer-local options to use for oil buffers
 ---@field win_options? table<string, any> Window-local options to use for oil buffers
 ---@field delete_to_trash? boolean Send deleted files to the trash instead of permanently deleting them (:help oil-trash).

--- a/lua/oil/init.lua
+++ b/lua/oil/init.lua
@@ -944,7 +944,7 @@ M._get_highlights = function()
       desc = "Virtual text that shows the original path of file in the trash",
     },
     {
-      name = "OilVirtualText",
+      name = "OilVirtText",
       link = "Comment",
       desc = "Virtual text in an oil buffer",
     },
@@ -1120,6 +1120,7 @@ local _on_key_ns = 0
 M.setup = function(opts)
   local Ringbuf = require("oil.ringbuf")
   local config = require("oil.config")
+  local view = require("oil.view")
 
   config.setup(opts)
   set_colors()
@@ -1307,6 +1308,10 @@ M.setup = function(opts)
       close_preview_window_if_not_in_oil()
     end,
   })
+  vim.api.nvim_create_autocmd("User", {
+    pattern = "OilEnter",
+    callback = view.constrain_cursor_on_enter
+  })
 
   vim.api.nvim_create_autocmd({ "BufWinEnter", "WinNew", "WinEnter" }, {
     desc = "Reset bufhidden when entering a preview buffer",
@@ -1402,7 +1407,6 @@ M.setup = function(opts)
   local ns = vim.api.nvim_create_namespace("OilVirtualColumns")
   vim.api.nvim_set_decoration_provider(ns, {
     on_win = function(_, winid, bufnr, toprow, botrow)
-      local view = require("oil.view")
       view.render_virtual_columns_on_win(ns, winid, bufnr, toprow, botrow)
     end,
   })

--- a/lua/oil/init.lua
+++ b/lua/oil/init.lua
@@ -50,7 +50,7 @@ M.get_entry_on_line = function(bufnr, lnum)
   if not line then
     return nil
   end
-  local column_defs = columns.get_supported_columns(adapter)
+  local column_defs = columns.get_editable_columns(adapter)
   local result = parser.parse_line(adapter, line, column_defs)
   if result then
     if result.entry then
@@ -943,6 +943,11 @@ M._get_highlights = function()
       link = "Comment",
       desc = "Virtual text that shows the original path of file in the trash",
     },
+    {
+      name = "OilVirtualText",
+      link = "Comment",
+      desc = "Virtual text in an oil buffer",
+    },
   }
 end
 
@@ -1391,6 +1396,14 @@ M.setup = function(opts)
       if config.adapters[scheme] and vim.api.nvim_buf_line_count(params.buf) == 1 then
         M.load_oil_buffer(params.buf)
       end
+    end,
+  })
+
+  local ns = vim.api.nvim_create_namespace("OilVirtualColumns")
+  vim.api.nvim_set_decoration_provider(ns, {
+    on_win = function(_, winid, bufnr, toprow, botrow)
+      local view = require("oil.view")
+      view.render_virtual_columns_on_win(ns, winid, bufnr, toprow, botrow)
     end,
   })
 


### PR DESCRIPTION
I'm a huge fan of oil, I use it constantly. Recently I turned on some of the metadata columns though and they've been bugging me enough that I desperately want to fix these problems:

A - Metadata columns should be able to be on the right (I totally agree with https://github.com/stevearc/oil.nvim/issues/496)
B - Columns should be able to have headers
C - metadata columns should be formattable with Lua functions

I previously tried to hack together a fix for B over here: #662 but it was pretty half baked and also only partially solved these problems for me.

So instead I set out on the goal of achieving all of the above in one go, by moving all the immutable metadata columns into virtual text. With virtual text, the constraint on the filename being at the end of a line and the constraint on column formats being parseable via string formats go away. The header row could still in theory be added separately, but the implementation of a header row with/without virtual columns are pretty different so I figured it be best to knock them both out at once in the same PR.

This PR is still a WIP, but I figured I'd open a draft to motivate myself to keep working on it, and potentially get a little help from anyone else interested in fixing these issues.

The current implementation is mostly working pretty well, but there are a couple quirks I've discovered about virtual text in neovim in the process of building it. I've documented some of the major learnings below to save anyone else wanting to dive in some time:

- I discovered early in the process that putting extmarks into the buffer on the normal render loop looked fine at first, but breaks down once you start making changes
  - for example, rendering extmarks on lines based on their content "works", but then if you delete that line, the content disappears but leaves behind the extmark. BAD experience for sure
  - another example, if you were to copy a line and paste it directly below the original, for example, you'd copy the buffer text but not the extmarks, meaning the freshly pasted line would be missing all of its virtual columns and alignment until the buffer is saved. also BAD, imo
  - The fix that I discovered for this was to use a decoration provider instead of rendering extmarks inside the existing render calls
    - With a decoration provider, neovim will render the extmarks on each redraw, which ensures all the columns and alignments and whatnot stay consistent, even for rows actively being edited (with the exception of new files created from scratch)
    - since the decoration provider uses the underlying entry objects cached for a given oil buffer, copying and pasting a line containing a file results in the same virtual columns as the original line being rendered, with metadata being updated accordingly on save
- I also discovered that rendering of extmarks with decoration providers on the neovim redraw loop doesn't update the cursor position correctly in some cases
  - for example, say the oil buffer renders the id and filename of a file on the first line and places the cursor on the first character of the filename. 
    - then the decoration provider comes in and renders the icon for the file with inline virtual text in front of the filename. 
      - I've seen that this can result in the buffer text moving over to accommodate the virtual text as expected, but the cursor block stays where it was before the virtual text was rendered, resulting in the cursor being incorrectly positioned on the virtual text. 
      - This seems to be a visual glitch only, as the actual cursor position in the buffer according to `vim.api.nvim_win_get_cursor` returns the correct column
- The hardest part of this whole project has been figuring out how to deal with cursor positioning, and especially glitches like the one above
  - it seems kinda janky, but putting delays and commands like `normal! 0` to trigger cursor moved events and whatnot in various places is required to get the cursor to behave as expected 
  

Anyways, the included changes in this PR are the following: (again, still WIP)

- New config option `virtual_text_columns`
  - when set to `true`, immutable columns will be rendered with virtual text
  - this also allows the `name` column to be configured in the existing `columns` config, so that virtual columns may be placed on the right side of the name column
- New config option `show_header`
  - when set to `true`, an empty line will be added to the top of every oil buffer and a header row will be rendered there with virtual text
  - This will also slightly change the behavior of some functionality like `constrain_cursor`, to prevent the header row from interfering with existing oil features
- New config option `header_format`
  - This one is an optional function that takes a raw column header string and should return a formatted custom header string to be used instead of the default raw column header
  - for example, your header format function can take in `BIRTHTIME` and spit out `Created at` to be rendered instead
- New capability to set a function for `format` in the `columns` config
  - This is only available when `virtual_text_columns` is true, otherwise buffer text metadata columns must remain parseable
  - for example, take a timestamp and spit out a string like `X days ago`

Here's an example of what my oil buffers look like on this branch:

 
<img width="456" height="378" alt="Screenshot 2025-09-18 at 2 28 32 PM" src="https://github.com/user-attachments/assets/0f88a54c-8e16-47a8-8ed9-1deb0755eeca" />
