### PR TITLE
fix `send_to_quickfix` opening qf when the target is `loclist`

### DIFF
--- a/lua/oil/util.lua
+++ b/lua/oil/util.lua
@@ -823,10 +823,10 @@ M.send_to_quickfix = function(opts)
   local action = opts.action == "a" and "a" or "r"
   if opts.target == "loclist" then
     vim.fn.setloclist(0, {}, action, { title = qf_title, items = qf_entries })
-		vim.cmd.lopen()
+    vim.cmd.lopen()
   else
     vim.fn.setqflist({}, action, { title = qf_title, items = qf_entries })
-		vim.cmd.copen()
+    vim.cmd.copen()
   end
   vim.api.nvim_exec_autocmds("QuickFixCmdPost", {})
 end


### PR DESCRIPTION
Just a 3-lines change to open the correct list based on the given target.