### PR TITLE
feat: include configuration to always skip confirmation popup

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,8 +163,8 @@ require("oil").setup({
   },
   -- Send deleted files to the trash instead of permanently deleting them (:help oil-trash)
   delete_to_trash = false,
-  -- Skip the confirmation popup for simple operations (:help oil.skip_confirm_for_simple_edits)
-  skip_confirm_for_simple_edits = false,
+  -- Determines when to skip the confirmation popup. Set to `true` to skip all operations, "simple" to skip for simple operations or `false` to never skip. (:help oil.skip_confirm)
+  skip_confirm = false,
   -- Selecting a new/moved/renamed file or directory will prompt you to save changes first
   -- (:help prompt_save_on_select_new_entry)
   prompt_save_on_select_new_entry = true,

--- a/doc/api.md
+++ b/doc/api.md
@@ -175,11 +175,11 @@ Select the entry under the cursor
 `save(opts, cb)` \
 Save all changes
 
-| Param    | Type                         | Desc                                                                                        |
-| -------- | ---------------------------- | ------------------------------------------------------------------------------------------- |
-| opts     | `nil\|table`                 |                                                                                             |
-| >confirm | `nil\|boolean`               | Show confirmation when true, never when false, respect skip_confirm_for_simple_edits if nil |
-| cb       | `nil\|fun(err: nil\|string)` | Called when mutations complete.                                                             |
+| Param    | Type                         | Desc                                                                       |
+| -------- | ---------------------------- | -------------------------------------------------------------------------- |
+| opts     | `nil\|table`                 |                                                                            |
+| >confirm | `nil\|boolean`               | Show confirmation when true, never when false, respect skip_confirm if nil |
+| cb       | `nil\|fun(err: nil\|string)` | Called when mutations complete.                                            |
 
 **Note:**
 <pre>

--- a/doc/oil.txt
+++ b/doc/oil.txt
@@ -45,8 +45,8 @@ CONFIG                                                                *oil-confi
       },
       -- Send deleted files to the trash instead of permanently deleting them (:help oil-trash)
       delete_to_trash = false,
-      -- Skip the confirmation popup for simple operations (:help oil.skip_confirm_for_simple_edits)
-      skip_confirm_for_simple_edits = false,
+      -- Determines when to skip the confirmation popup. Set to `true` to skip all operations, "simple" to skip for simple operations or `false` to never skip. (:help oil.skip_confirm).
+      skip_confirm = false,
       -- Selecting a new/moved/renamed file or directory will prompt you to save changes first
       -- (:help prompt_save_on_select_new_entry)
       prompt_save_on_select_new_entry = true,
@@ -223,11 +223,12 @@ CONFIG                                                                *oil-confi
 OPTIONS                                                              *oil-options*
 
 
-skip_confirm_for_simple_edits                  *oil.skip_confirm_for_simple_edits*
-    type: `boolean` default: `false`
+skip_confirm                                 *oil.skip_confirm*
+    type: `boolean`|"simple" default: `false`
     Before performing filesystem operations, Oil displays a confirmation popup to ensure
-    that all operations are intentional. When this option is `true`, the popup will be
-    skipped if the operations:
+    that all operations are intentional. When this option is `true` or `false`, the popup
+    is toggled (`true` the popup will always be skipped, `false` will never be skipped).
+    When setted to "simple", the popup will be skipped if the operations:
         * contain no deletes
         * contain no cross-adapter moves or copies (e.g. from local to ssh)
         * contain at most one copy or move
@@ -386,7 +387,7 @@ save({opts}, {cb})                                                      *oil.sav
     Parameters:
       {opts} `nil|table`
           {confirm} `nil|boolean` Show confirmation when true, never when false,
-                    respect skip_confirm_for_simple_edits if nil
+                    respect skip_confirm if nil
       {cb}   `nil|fun(err: nil|string)` Called when mutations complete.
 
     Note:

--- a/lua/oil/config.lua
+++ b/lua/oil/config.lua
@@ -28,8 +28,8 @@ local default_config = {
   },
   -- Send deleted files to the trash instead of permanently deleting them (:help oil-trash)
   delete_to_trash = false,
-  -- Skip the confirmation popup for simple operations (:help oil.skip_confirm_for_simple_edits)
-  skip_confirm_for_simple_edits = false,
+  -- Determines when to skip the confirmation popup. Set to `true` to skip all operations, "simple" to skip for simple operations or `false` to never skip. (:help oil.skip_confirm).
+  skip_confirm = false,
   -- Selecting a new/moved/renamed file or directory will prompt you to save changes first
   -- (:help prompt_save_on_select_new_entry)
   prompt_save_on_select_new_entry = true,
@@ -224,7 +224,7 @@ default_config.view_options.highlight_filename = nil
 ---@field buf_options table<string, any>
 ---@field win_options table<string, any>
 ---@field delete_to_trash boolean
----@field skip_confirm_for_simple_edits boolean
+---@field skip_confirm boolean|"simple"
 ---@field prompt_save_on_select_new_entry boolean
 ---@field cleanup_delay_ms integer
 ---@field lsp_file_methods oil.LspFileMethods
@@ -252,7 +252,7 @@ local M = {}
 ---@field buf_options? table<string, any> Buffer-local options to use for oil buffers
 ---@field win_options? table<string, any> Window-local options to use for oil buffers
 ---@field delete_to_trash? boolean Send deleted files to the trash instead of permanently deleting them (:help oil-trash).
----@field skip_confirm_for_simple_edits? boolean Skip the confirmation popup for simple operations (:help oil.skip_confirm_for_simple_edits).
+---@field skip_confirm? boolean|"simple" Determines when to skip the confirmation popup. Set to `true` to skip all operations, "simple" to skip for simple operations or `false` to never skip. (:help oil.skip_confirm).
 ---@field prompt_save_on_select_new_entry? boolean Selecting a new/moved/renamed file or directory will prompt you to save changes first (:help prompt_save_on_select_new_entry).
 ---@field cleanup_delay_ms? integer Oil will automatically delete hidden buffers after this delay. You can set the delay to false to disable cleanup entirely. Note that the cleanup process only starts when none of the oil buffers are currently displayed.
 ---@field lsp_file_methods? oil.SetupLspFileMethods Configure LSP file operation integration.

--- a/lua/oil/init.lua
+++ b/lua/oil/init.lua
@@ -975,7 +975,7 @@ end
 
 ---Save all changes
 ---@param opts nil|table
----    confirm nil|boolean Show confirmation when true, never when false, respect skip_confirm_for_simple_edits if nil
+---    confirm nil|boolean Show confirmation when true, never when false, respect skip_confirm if nil
 ---@param cb? fun(err: nil|string) Called when mutations complete.
 ---@note
 --- If you provide your own callback function, there will be no notification for errors.

--- a/lua/oil/mutator/confirmation.lua
+++ b/lua/oil/mutator/confirmation.lua
@@ -63,7 +63,10 @@ M.show = vim.schedule_wrap(function(actions, should_confirm, cb)
     cb(true)
     return
   end
-  if should_confirm == nil and config.skip_confirm_for_simple_edits and is_simple_edit(actions) then
+  if
+    should_confirm == nil
+    and (config.skip_confirm == true or config.skip_confirm == "simple" and is_simple_edit(actions))
+  then
     cb(true)
     return
   end

--- a/scripts/generate.py
+++ b/scripts/generate.py
@@ -195,11 +195,12 @@ def get_options_detail_vimdoc() -> "VimdocSection":
     section = VimdocSection("options", "oil-options")
     section.body.append(
         """
-skip_confirm_for_simple_edits                  *oil.skip_confirm_for_simple_edits*
-    type: `boolean` default: `false`
+skip_confirm                                 *oil.skip_confirm*
+    type: `boolean`|"simple" default: `false`
     Before performing filesystem operations, Oil displays a confirmation popup to ensure
-    that all operations are intentional. When this option is `true`, the popup will be
-    skipped if the operations:
+    that all operations are intentional. When this option is `true` or `false`, the popup
+    is toggled (`true` the popup will always be skipped, `false` will never be skipped).
+    When setted to "simple", the popup will be skipped if the operations:
         * contain no deletes
         * contain no cross-adapter moves or copies (e.g. from local to ssh)
         * contain at most one copy or move


### PR DESCRIPTION
This PR changes the `skip_confirm_for_simple_edits` config option so the confirmation popup can always be skipped.

The property name was changed to `skip_confirm` for better fitting the new option to skip all.

The property values can be:
- `true` so it will ALWAYS skip the confirmation popup.
- `false` so it will NEVER skip the confirmation popup.
- "simple" so it will only be skipped for simple operations.

I tried to add this feature without breaking the configuration of the current users (like myself), but I thought that creating another config property was going to be confusing.

Happy to receive any suggestions!