### PR TITLE
fix!: use `g~` over `~`

### DIFF
--- a/lua/oil/config.lua
+++ b/lua/oil/config.lua
@@ -69,7 +69,7 @@ local default_config = {
     ["-"] = { "actions.parent", mode = "n" },
     ["_"] = { "actions.open_cwd", mode = "n" },
     ["`"] = { "actions.cd", mode = "n" },
-    ["~"] = { "actions.cd", opts = { scope = "tab" }, mode = "n" },
+    ["g~"] = { "actions.cd", opts = { scope = "tab" }, mode = "n" },
     ["gs"] = { "actions.change_sort", mode = "n" },
     ["gx"] = "actions.open_external",
     ["g."] = { "actions.toggle_hidden", mode = "n" },


### PR DESCRIPTION
I am opening a PR to see if you are open to this. This will essentially be a breaking change, but I have seen a couple of issues around this, and also that you have regretted the decision to use `~` as a mapping.

~Specifically for me, it was kind of annoying that `<C-l>` and `<C-h>` was mapped by default since I have those mapped to `<C-w>l` and `<C-w>h`~


~which I also would say are quite regular default mappings~

Let me know what you think about this! Hope you can consider!