### PR TITLE
support multicursor.nvim

### DIFF
--- a/lua/oil/view.lua
+++ b/lua/oil/view.lua
@@ -282,7 +282,6 @@ local function calc_constrained_cursor_pos(bufnr, adapter, mode, cur)
   end
 end
 
-
 ---Force cursor to be after hidden/immutable columns
 ---@param bufnr integer
 ---@param mode false|"name"|"editable"
@@ -304,10 +303,10 @@ local function constrain_cursor(bufnr, mode)
     mc.onSafeState(function()
       mc.action(function(ctx)
         ctx:forEachCursor(function(cursor)
-          local new_cur = calc_constrained_cursor_pos(
-            bufnr, adapter, mode, { cursor:line(), cursor:col() - 1 })
+          local new_cur =
+            calc_constrained_cursor_pos(bufnr, adapter, mode, { cursor:line(), cursor:col() - 1 })
           if new_cur then
-            cursor:setPos({new_cur[1], new_cur[2] + 1})
+            cursor:setPos({ new_cur[1], new_cur[2] + 1 })
           end
         end)
       end)
@@ -319,7 +318,6 @@ local function constrain_cursor(bufnr, mode)
       vim.api.nvim_win_set_cursor(0, new_cur)
     end
   end
-
 end
 
 ---Redraw original path virtual text for trash buffer


### PR DESCRIPTION
Users have expressed desire to use your plugin with multicursor.nvim

https://github.com/jake-stewart/multicursor.nvim/issues/140

This PR simply checks whether `multicursor.nvim` is already loaded and if so applies the cursor adjustment to each virtual cursor.

I changed the code slightly so that there is a common function for calculating the correct cursor position. I call this for each cursor. This is to avoid getting/setting cursor state for each cursor. I use the cached cursor state when calling the function.