### PR TITLE
fix: handle empty LSP glob patterns

### DIFF
--- a/lua/oil/lsp/workspace.lua
+++ b/lua/oil/lsp/workspace.lua
@@ -79,9 +79,9 @@ local function get_matching_paths(client, filters, paths)
         glob = glob:gsub("{(.-)}", function(s)
           local patterns = vim.split(s, ",")
           local filtered = {}
-          for _, pattern in ipairs(patterns) do
-            if pattern ~= "" then
-              table.insert(filtered, pattern)
+          for _, pat in ipairs(patterns) do
+            if pat ~= "" then
+              table.insert(filtered, pat)
             end
           end
           if #filtered == 0 then


### PR DESCRIPTION
fixes: #672
I have a [screencast](https://www.youtube.com/watch?v=ETdbe828e6M) of the issue + this patch.

[The LSP spec for glob patterns](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#fileOperationPattern) defines the syntax for "*group sub patterns*" but doesn't mention anything about empty patterns.

Somehow (not investigated) we end up with an empty `s` parameter being passed to our `glob` function, so I assume that since such a pattern isn't explicitly forbidden, that language servers (TSserver, marksman, et al.) emit them?
(Maybe this is worth checking up front if `s` is empty, but `if #filtered == 0 then` catches this. Might be even better to not call this function at all in some higher scopes but I'm not sure.)

Imagine patterns such as: `**/*.{md,}`, `**/*.{}`, `**/*.{foo,,bar}`.
These patterns get rejected by the parser for `vim.glob.to_lpeg()`: `Invalid glob: **/*.{}`.

---

This change replaces `glob` so that patterns are always sanitized and conditionally sorted before being passed to `to_lpeg()`.
So that `*.{}` is treated like `*`, `*.{md,}` -> `*.{md}`, `*.{foo,,bar}` -> `*.{foo,bar}`.
I believe these are all permissible in the current spec, so we account for them.

---

There may be a better way to solve this, I'm not sure.
This works for me in my use case (`NVIM v0.12.0-dev-1908+g47aef025a7` on Windows) but could use some testing from others.
Older vim users, people reporting this issue on other platforms + LSP servers and scenarios, etc.
Hopefully this approach doesn't break any existing workflows.