### PR TITLE
docs: add async oil-git.nvim fork to third-party extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,6 +379,7 @@ These are plugins maintained by other authors that extend the functionality of o
 
 - [oil-git-status.nvim](https://github.com/refractalize/oil-git-status.nvim) - Shows git status of files in statuscolumn
 - [oil-git.nvim](https://github.com/benomahony/oil-git.nvim) - Shows git status of files with colour and symbols
+- [oil-git.nvim (async fork)](https://github.com/malewicz1337/oil-git.nvim) - Async git status with file/directory highlighting, debouncing
 - [oil-lsp-diagnostics.nvim](https://github.com/JezerM/oil-lsp-diagnostics.nvim) - Shows LSP diagnostics indicator as virtual text
 
 ## API


### PR DESCRIPTION
Summary:
Adds my async fork of `oil-git.nvim` to the third-party extensions list.

Changes:
- Added [malewicz1337/oil-git.nvim](https://github.com/malewicz1337/oil-git.nvim) to the third-party extensions section

About the plugin:
This is an improved fork of benomahony/oil-git.nvim with:
- non-blocking git operations
- aggregate status of directory contents
- configurable debounce to prevent excessive refreshes
- support for deleted, copied, and conflict states

I've kept the original plugin listed as it still serves users who prefer the simpler synchronous implementation. This PR simply adds my fork as an additional option for users who want async support and the extra features.