### PR TITLE
fix: propagate errors in recursive_delete and recursive_copy

### DIFF
--- a/lua/oil/fs.lua
+++ b/lua/oil/fs.lua
@@ -218,7 +218,7 @@ M.recursive_delete = function(entry_type, path, cb)
           local waiting = #entries
           local complete
           complete = function(err2)
-            if err then
+            if err2 then
               complete = function() end
               return inner_cb(err2)
             end
@@ -320,7 +320,7 @@ M.recursive_copy = function(entry_type, src_path, dest_path, cb)
               local waiting = #entries
               local complete
               complete = function(err2)
-                if err then
+                if err2 then
                   complete = function() end
                   return inner_cb(err2)
                 end


### PR DESCRIPTION
The `complete` callback in `recursive_delete` and `recursive_copy` checks `err` instead of `err2`, but `err` is always nil inside the `elseif entries` branch. This silently ignores child operation errors, causing misleading "directory not empty" failures.

The correct pattern is already used elsewhere in the codebase:
- `recursive_move` (line 362)
- `trash/windows.lua` (line 336)