### PR TITLE
Enable preview-split for non-floating view

### DIFF
--- a/lua/oil/config.lua
+++ b/lua/oil/config.lua
@@ -155,6 +155,8 @@ local default_config = {
     end,
     -- Window-local options to use for preview window buffers
     win_options = {},
+    -- Split direction for preview window in regular (non-floating) buffers: "auto", "left", "right", "above", "below"
+    split = "auto",
   },
   -- Configuration for the floating action confirmation window
   confirmation = {
@@ -356,6 +358,7 @@ local M = {}
 ---@field preview_method oil.PreviewMethod
 ---@field disable_preview fun(filename: string): boolean
 ---@field win_options table<string, any>
+---@field split "auto"|"left"|"right"|"above"|"below"
 
 ---@class (exact) oil.ConfirmationWindowConfig : oil.WindowConfig
 
@@ -364,6 +367,7 @@ local M = {}
 ---@field disable_preview? fun(filename: string): boolean A function that returns true to disable preview on a file e.g. to avoid lag
 ---@field preview_method? oil.PreviewMethod How to open the preview window
 ---@field win_options? table<string, any> Window-local options to use for preview window buffers
+---@field split? "auto"|"left"|"right"|"above"|"below" Split direction for preview window in regular (non-floating) buffers
 
 ---@class (exact) oil.SetupConfirmationWindowConfig : oil.SetupWindowConfig
 

--- a/lua/oil/init.lua
+++ b/lua/oil/init.lua
@@ -466,10 +466,23 @@ M.open_preview = function(opts, callback)
     opts.vertical = true
   end
   if not opts.split then
+    local preview_split = config.preview_win.split
     if opts.horizontal then
-      opts.split = vim.o.splitbelow and "belowright" or "aboveleft"
+      if preview_split == "below" then
+        opts.split = "belowright"
+      elseif preview_split == "above" then
+        opts.split = "aboveleft"
+      else
+        opts.split = vim.o.splitbelow and "belowright" or "aboveleft"
+      end
     else
-      opts.split = vim.o.splitright and "belowright" or "aboveleft"
+      if preview_split == "right" then
+        opts.split = "belowright"
+      elseif preview_split == "left" then
+        opts.split = "aboveleft"
+      else
+        opts.split = vim.o.splitright and "belowright" or "aboveleft"
+      end
     end
   end
 


### PR DESCRIPTION
Hello ! I was facing the same problem as described [here](https://github.com/stevearc/oil.nvim/issues/304), but figured an alternative solution  that doesn't make me modify Oil.

I still got to a point where I could easily select the direction for vertical splits, I could not figure out how to configure it so it would be horizontal so I can't confirm it works for that.

I don't know if it matches the standards of this repo or good practices of Lua, but as it could be a nice addition I thought I would still share what I have.
I have an alternative solution so feel free to close the PR !