### PR TITLE
docs: Fix s3 column descriptions

### DIFF
--- a/doc/oil.txt
+++ b/doc/oil.txt
@@ -430,7 +430,7 @@ icon                                                                 *column-ico
                      the icon
 
 size                                                                 *column-size*
-    Adapters: files, ssh
+    Adapters: files, ssh, s3
     Sortable: this column can be used in view_props.sort
     The size of the file
 
@@ -478,7 +478,7 @@ atime                                                               *column-atim
       {format}    `string` Format string (see :help strftime)
 
 birthtime                                                       *column-birthtime*
-    Adapters: files
+    Adapters: files, s3
     Sortable: this column can be used in view_props.sort
     The time the file was created
 

--- a/scripts/generate.py
+++ b/scripts/generate.py
@@ -151,7 +151,7 @@ COL_DEFS = [
             ),
         ],
     ),
-    ColumnDef("size", "files, ssh", False, True, "The size of the file", HL + []),
+    ColumnDef("size", "files, ssh, s3", False, True, "The size of the file", HL + []),
     ColumnDef(
         "permissions",
         "files, ssh",
@@ -171,7 +171,7 @@ COL_DEFS = [
     ),
     ColumnDef(
         "birthtime",
-        "files",
+        "files, s3",
         False,
         True,
         "The time the file was created",


### PR DESCRIPTION
I noticed that I didn't add this to the docs correctly in the original s3 adapter PR. 