### PR TITLE
docs: add malewicz1337/oil-git.nvim to third-party extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,6 +379,7 @@ These are plugins maintained by other authors that extend the functionality of o
 
 - [oil-git-status.nvim](https://github.com/refractalize/oil-git-status.nvim) - Shows git status of files in statuscolumn
 - [oil-git.nvim](https://github.com/benomahony/oil-git.nvim) - Shows git status of files with colour and symbols
+- [oil-git.nvim](https://github.com/malewicz1337/oil-git.nvim) - Async git status integration with directory support
 - [oil-lsp-diagnostics.nvim](https://github.com/JezerM/oil-lsp-diagnostics.nvim) - Shows LSP diagnostics indicator as virtual text
 
 ## API


### PR DESCRIPTION
added [malewicz1337/oil-git.nvim](https://github.com/malewicz1337/oil-git.nvim) to the third-party extensions list

its a maintained fork of `benomahony/oil-git.nvim` with async exec, directory highlighting, and debounced updates to prevent flickering. I kept the original plugin in the list as well so users can choose whichever one works best for them

i tried to keep the description brief, but please let me know if you want me to rephrase

it would be an honor to see this added to the list if you think it fits)