### PR TITLE
feature: add create_hook to populate file contents during creation

### DIFF
--- a/lua/oil/adapters/files.lua
+++ b/lua/oil/adapters/files.lua
@@ -600,6 +600,13 @@ M.perform_action = function(action, cb)
       ---@diagnostic disable-next-line: param-type-mismatch
       uv.fs_symlink(target, path, flags, cb)
     else
+      local hook = config.create_hook
+      if hook then
+        local ok, content = pcall(hook, action)
+        if ok and content then
+          return fs.write_file(path, content, cb)
+        end
+      end
       fs.touch(path, cb)
     end
   elseif action.type == "delete" then

--- a/lua/oil/config.lua
+++ b/lua/oil/config.lua
@@ -201,6 +201,11 @@ local default_config = {
   keymaps_help = {
     border = nil,
   },
+  -- Optional function to call before creating a new file.
+  -- Return nil to create an empty file or a string to use as the file content.
+  -- @param action oil.Action The create action being performed.
+  -- @return nil|string The content to write to the file or nil for empty file.
+  create_hook = nil,
 }
 
 -- The adapter API hasn't really stabilized yet. We're not ready to advertise or encourage people to
@@ -248,6 +253,7 @@ default_config.view_options.highlight_filename = nil
 ---@field progress oil.ProgressWindowConfig
 ---@field ssh oil.SimpleWindowConfig
 ---@field keymaps_help oil.SimpleWindowConfig
+---@field create_hook? fun(action: oil.Action): nil|string
 local M = {}
 
 -- For backwards compatibility
@@ -277,6 +283,7 @@ local M = {}
 ---@field progress? oil.SetupProgressWindowConfig Configuration for the floating progress window
 ---@field ssh? oil.SetupSimpleWindowConfig Configuration for the floating SSH window
 ---@field keymaps_help? oil.SetupSimpleWindowConfig Configuration for the floating keymaps help window
+---@field create_hook? fun(action: oil.Action): nil|string Optional function to call before creating a new file. Return nil to create an empty file or a string to use that as the file content.
 
 ---@class (exact) oil.LspFileMethods
 ---@field enabled boolean

--- a/lua/oil/fs.lua
+++ b/lua/oil/fs.lua
@@ -49,6 +49,24 @@ M.touch = function(path, cb)
   end)
 end
 
+---@param path string
+---@param content string
+---@param cb fun(err: nil|string)
+M.write_file = function(path, content, cb)
+  local fd = uv.fs_open(path, "w", 420)
+  if not fd then
+    cb("failed to open file: " .. path)
+    return
+  end
+  local success, write_err = pcall(uv.fs_write, fd, content)
+  uv.fs_close(fd)
+  if not success then
+    cb("failed to write file: " .. tostring(write_err))
+	return
+  end
+  cb(nil)
+end
+
 --- Returns true if candidate is a subpath of root, or if they are the same path.
 ---@param root string
 ---@param candidate string

--- a/tests/create_hook_spec.lua
+++ b/tests/create_hook_spec.lua
@@ -1,0 +1,136 @@
+require("plenary.async").tests.add_to_env()
+local TmpDir = require("tests.tmpdir")
+local files = require("oil.adapters.files")
+local test_util = require("tests.test_util")
+local config = require("oil.config")
+
+a.describe("create_hook", function()
+  local tmpdir
+  local original_hook
+
+  a.before_each(function()
+    tmpdir = TmpDir.new()
+    original_hook = config.create_hook
+    config.create_hook = nil
+  end)
+
+  a.after_each(function()
+    config.create_hook = original_hook
+    if tmpdir then
+      tmpdir:dispose()
+    end
+    test_util.reset_editor()
+  end)
+
+  a.it("creates empty file when hook returns nil", function()
+    config.create_hook = function(action)
+      return nil
+    end
+
+    local err = a.wrap(files.perform_action, 2)({
+      url = "oil://" .. vim.fn.fnamemodify(tmpdir.path, ":p") .. "test.txt",
+      entry_type = "file",
+      type = "create",
+    })
+
+    assert.is_nil(err)
+    tmpdir:assert_fs({
+      ["test.txt"] = "",
+    })
+  end)
+
+  a.it("creates file with hook content", function()
+    config.create_hook = function(action)
+      return "hello world"
+    end
+
+    local err = a.wrap(files.perform_action, 2)({
+      url = "oil://" .. vim.fn.fnamemodify(tmpdir.path, ":p") .. "test.txt",
+      entry_type = "file",
+      type = "create",
+    })
+
+    assert.is_nil(err)
+    tmpdir:assert_fs({
+      ["test.txt"] = "hello world",
+    })
+  end)
+
+  a.it("handles hook errors gracefully", function()
+    config.create_hook = function(action)
+      error("hook error")
+    end
+
+    local err = a.wrap(files.perform_action, 2)({
+      url = "oil://" .. vim.fn.fnamemodify(tmpdir.path, ":p") .. "test.txt",
+      entry_type = "file",
+      type = "create",
+    })
+
+    -- Should fall back to empty file creation
+    assert.is_nil(err)
+    tmpdir:assert_fs({
+      ["test.txt"] = "",
+    })
+  end)
+
+  a.it("passes action to hook", function()
+    local received_action
+    config.create_hook = function(action)
+      received_action = action
+      return nil
+    end
+
+    a.wrap(files.perform_action, 2)({
+      url = "oil://" .. vim.fn.fnamemodify(tmpdir.path, ":p") .. "foo.go",
+      entry_type = "file",
+      type = "create",
+    })
+
+    assert.is_not_nil(received_action)
+    assert.equals("create", received_action.type)
+    assert.equals("file", received_action.entry_type)
+    assert.is_truthy(received_action.url:match("foo.go$"))
+  end)
+
+  a.it("creates file with custom content based on extension", function()
+    config.create_hook = function(action)
+      if action.url:match("%.sh$") then
+        return "#!/bin/bash\n"
+      elseif action.url:match("%.go$") then
+        return "package main\n"
+      end
+      return nil
+    end
+
+    -- Create shell script
+    local err1 = a.wrap(files.perform_action, 2)({
+      url = "oil://" .. vim.fn.fnamemodify(tmpdir.path, ":p") .. "script.sh",
+      entry_type = "file",
+      type = "create",
+    })
+    assert.is_nil(err1)
+
+    -- Create go file
+    local err2 = a.wrap(files.perform_action, 2)({
+      url = "oil://" .. vim.fn.fnamemodify(tmpdir.path, ":p") .. "main.go",
+      entry_type = "file",
+      type = "create",
+    })
+    assert.is_nil(err2)
+
+    -- Create other file (should be empty)
+    local err3 = a.wrap(files.perform_action, 2)({
+      url = "oil://" .. vim.fn.fnamemodify(tmpdir.path, ":p") .. "readme.txt",
+      entry_type = "file",
+      type = "create",
+    })
+    assert.is_nil(err3)
+
+    tmpdir:assert_fs({
+      ["script.sh"] = "#!/bin/bash\n",
+      ["main.go"] = "package main\n",
+      ["readme.txt"] = "",
+    })
+  end)
+end)


### PR DESCRIPTION
I've been using this for a few days and like it. Maybe we should add it or something like it?

My particular use case (preceded by meandering and rambling):
https://www.youtube.com/watch?v=dJc4-S2jvMs

---

I'm not the most familiar with everything involved so this is just my best attempt by mostly copy-pasting from other parts of the code that deal with libuv. It may be possible to use a callback to make all the io calls async, but I didn't want to play with fire without confidence.

Likewise with the tests and other stuff, it's just copy pasted from other sections and modified slightly.
The only thing I really did was insert the hook into the action sequence.

---

This seems to work but is marked as a draft since the API could change depending on testing, feedback, maintainer approval, etc.
Edit: been using this for a while without issue, removing draft status.