### PR TITLE
emit OilEnter when rendering after file system change

### DIFF
--- a/lua/oil/view.lua
+++ b/lua/oil/view.lua
@@ -867,7 +867,19 @@ local pending_renders = {}
 ---@param opts nil|table
 ---    refetch nil|boolean Defaults to true
 ---@param callback nil|fun(err: nil|string)
-M.render_buffer_async = function(bufnr, opts, callback)
+M.render_buffer_async = function(bufnr, opts, caller_callback)
+  local function callback(err)
+    if not err then
+      vim.api.nvim_exec_autocmds(
+        "User",
+        { pattern = "OilReadPost", modeline = false, data = { buf = bufnr } }
+      )
+    end
+    if caller_callback then
+      caller_callback(err)
+    end
+  end
+
   opts = vim.tbl_deep_extend("keep", opts or {}, {
     refetch = true,
   })


### PR DESCRIPTION
The https://github.com/refractalize/oil-git-status.nvim plugin has an issue that when a filesystem change is detected, the git status is cleared. This is because the oil buffer is rendered following the filesystem change, which clears the git status column, but there's no way for the git status plugin to know to that it needs to update the git status again.

Ideally the git status plugin would simply respond to an event each time an oil buffer is rendered, regardless for the reason. I've made an attempt to do that in this PR, emitting a new `OilReadPost` autocmd each time we successfully render an oil buffer. This seems to cover all the cases that the git status plugin needs to update the git status for the buffer.