### PR TITLE
fix: normalize keymap keys before merging user config

### DIFF
--- a/lua/oil/config.lua
+++ b/lua/oil/config.lua
@@ -409,6 +409,12 @@ M.setup = function(opts)
     -- We don't want to deep merge the keymaps, we want any keymap defined by the user to override
     -- everything about the default.
     for k, v in pairs(opts.keymaps) do
+      local normalized = vim.api.nvim_replace_termcodes(k, true, true, true)
+      for existing_k, _ in pairs(new_conf.keymaps) do
+        if existing_k ~= k and vim.api.nvim_replace_termcodes(existing_k, true, true, true) == normalized then
+          new_conf.keymaps[existing_k] = nil
+        end
+      end
       new_conf.keymaps[k] = v
     end
   end


### PR DESCRIPTION
## Problem

Keymap overrides using non-canonical casing (e.g. `<c-t>` instead of `<C-t>`) fail to replace the corresponding default keymap. The keys are compared as raw strings during the merge in `config.setup()`, so both the user entry and the default entry remain in the table. Depending on `pairs()` iteration order, the default may overwrite the user's override when applied via `vim.keymap.set`.

## Solution

Normalize keymap keys with `vim.api.nvim_replace_termcodes` during the merge loop. Before inserting each user keymap, any existing default key that normalizes to the same internal representation is removed, ensuring the user's entry is the only one that survives.

Closes #692