### PR TITLE
fix: normalize keymap keys before merging user config

### DIFF
--- a/lua/oil/config.lua
+++ b/lua/oil/config.lua
@@ -409,6 +409,12 @@ M.setup = function(opts)
     -- We don't want to deep merge the keymaps, we want any keymap defined by the user to override
     -- everything about the default.
     for k, v in pairs(opts.keymaps) do
+      local normalized = vim.api.nvim_replace_termcodes(k, true, true, true)
+      for existing_k, _ in pairs(new_conf.keymaps) do
+        if existing_k ~= k and vim.api.nvim_replace_termcodes(existing_k, true, true, true) == normalized then
+          new_conf.keymaps[existing_k] = nil
+        end
+      end
       new_conf.keymaps[k] = v
     end
   end


### PR DESCRIPTION
Problem: user keymap overrides like <c-t> failed to replace the default <C-t> because the keys were compared as raw strings during merge, leaving both entries in the table.

Solution: use nvim_replace_termcodes to compare keymap keys by their internal representation, removing any default entry that normalizes to the same key as the user-provided one before inserting it.