### PR TITLE
gX opens external program with a selection.

### DIFF
--- a/lua/oil/actions.lua
+++ b/lua/oil/actions.lua
@@ -330,6 +330,46 @@ M.open_external = {
   end,
 }
 
+local programs = {
+  { name = "xdg-open (default)", cmd = function(path) return { "xdg-open", path } end },
+  { name = "Firefox",            cmd = function(path) return { "firefox", path } end },
+  { name = "Chrome",             cmd = function(path) return { "google-chrome", path } end },
+  { name = "VLC",                cmd = function(path) return { "vlc", path } end },
+  { name = "Open with custom…",  cmd = "custom" },
+}
+
+local function pick_and_open(path)
+  vim.ui.select(programs, {
+    prompt = "Open with:",
+    format_item = function(it) return it.name end,
+  }, function(choice)
+    if not choice then return end
+
+    if choice.cmd == "custom" then
+      vim.ui.input({ prompt = "Program: " }, function(prog)
+        if not prog or prog == "" then return end
+        vim.fn.jobstart({ prog, path }, { detach = true })
+      end)
+      return
+    end
+
+    local cmd = choice.cmd(path)
+    vim.fn.jobstart(cmd, { detach = true })
+  end)
+end
+
+M.open_external_select = {
+  desc = "Open the entry under the cursor in an external program selection",
+  callback = function()
+    local entry = oil.get_cursor_entry()
+    local dir = oil.get_current_dir()
+    if not entry or not dir then return end
+
+    local path = dir .. entry.name
+    pick_and_open(path)
+  end,
+}
+
 M.refresh = {
   desc = "Refresh current directory list",
   callback = function(opts)

--- a/lua/oil/actions.lua
+++ b/lua/oil/actions.lua
@@ -332,8 +332,9 @@ M.open_external = {
 
 local programs = {
   { name = "xdg-open (default)", cmd = function(path) return { "xdg-open", path } end },
-  { name = "Firefox",            cmd = function(path) return { "firefox", path } end },
   { name = "Chrome",             cmd = function(path) return { "google-chrome", path } end },
+  { name = "Okular",             cmd = function(path) return { "okular", path } end },
+  { name = "Firefox",            cmd = function(path) return { "firefox", path } end },
   { name = "VLC",                cmd = function(path) return { "vlc", path } end },
   { name = "Open with custom…",  cmd = "custom" },
 }

--- a/lua/oil/config.lua
+++ b/lua/oil/config.lua
@@ -72,6 +72,7 @@ local default_config = {
     ["g~"] = { "actions.cd", opts = { scope = "tab" }, mode = "n" },
     ["gs"] = { "actions.change_sort", mode = "n" },
     ["gx"] = "actions.open_external",
+    ["gX"] = "actions.open_external_select",
     ["g."] = { "actions.toggle_hidden", mode = "n" },
     ["g\\"] = { "actions.toggle_trash", mode = "n" },
   },


### PR DESCRIPTION
### The actual change
This change allows to open external programs not only in the default program set by the OS but to choose from a list.

### Further possible changes
Since I struggled to implement this correctly, maybe someone else can do this:
1. The `g?` help should sort this such that `gX` is directly below `gx`.
2. There is a new config option (besides the default) in oil which allows to define these external programs in a table.
