### PR TITLE
fix: use os path when watching for changes

### DIFF
--- a/lua/oil/view.lua
+++ b/lua/oil/view.lua
@@ -499,37 +499,39 @@ M.initialize = function(bufnr)
     local fs_event = assert(uv.new_fs_event())
     local bufname = vim.api.nvim_buf_get_name(bufnr)
     local _, dir = util.parse_url(bufname)
-    local os_dir = fs.posix_to_os_path(assert(dir))
-    fs_event:start(
-      os_dir,
-      {},
-      vim.schedule_wrap(function(err, filename, events)
-        if not vim.api.nvim_buf_is_valid(bufnr) then
-          local sess = session[bufnr]
-          if sess then
-            sess.fs_event = nil
-          end
-          fs_event:stop()
-          return
-        end
-        local mutator = require("oil.mutator")
-        if err or vim.bo[bufnr].modified or vim.b[bufnr].oil_dirty or mutator.is_mutating() then
-          return
-        end
-
-        -- If the buffer is currently visible, rerender
-        for _, winid in ipairs(vim.api.nvim_list_wins()) do
-          if vim.api.nvim_win_is_valid(winid) and vim.api.nvim_win_get_buf(winid) == bufnr then
-            M.render_buffer_async(bufnr)
+    if not (fs.is_windows and dir == '/') then
+      local os_path = fs.posix_to_os_path(assert(dir))
+      fs_event:start(
+        os_path,
+        {},
+        vim.schedule_wrap(function(err, filename, events)
+          if not vim.api.nvim_buf_is_valid(bufnr) then
+            local sess = session[bufnr]
+            if sess then
+              sess.fs_event = nil
+            end
+            fs_event:stop()
             return
           end
-        end
+          local mutator = require("oil.mutator")
+          if err or vim.bo[bufnr].modified or vim.b[bufnr].oil_dirty or mutator.is_mutating() then
+            return
+          end
 
-        -- If it is not currently visible, mark it as dirty
-        vim.b[bufnr].oil_dirty = {}
-      end)
-    )
-    session[bufnr].fs_event = fs_event
+          -- If the buffer is currently visible, rerender
+          for _, winid in ipairs(vim.api.nvim_list_wins()) do
+            if vim.api.nvim_win_is_valid(winid) and vim.api.nvim_win_get_buf(winid) == bufnr then
+              M.render_buffer_async(bufnr)
+              return
+            end
+          end
+
+          -- If it is not currently visible, mark it as dirty
+          vim.b[bufnr].oil_dirty = {}
+        end)
+      )
+      session[bufnr].fs_event = fs_event
+    end
   end
 
   -- Watch for TextChanged and update the trash original path extmarks

--- a/lua/oil/view.lua
+++ b/lua/oil/view.lua
@@ -499,8 +499,9 @@ M.initialize = function(bufnr)
     local fs_event = assert(uv.new_fs_event())
     local bufname = vim.api.nvim_buf_get_name(bufnr)
     local _, dir = util.parse_url(bufname)
+    local os_dir = fs.posix_to_os_path(assert(dir))
     fs_event:start(
-      assert(dir),
+      os_dir,
       {},
       vim.schedule_wrap(function(err, filename, events)
         if not vim.api.nvim_buf_is_valid(bufnr) then


### PR DESCRIPTION
Call `fs.posix_to_os_path` on the path parsed from the `oil://*`-url before handing it off to uv.fs_event_start. Not doing so breaks `watch_for_changes` on MS Windows.

(On Windows `oil://C/mydir/subdir/` would cause `uv.fs_event_start` to be called with `C/mydir/subdir/` rather than `C:\mydir\subdir\`)