### PR TITLE
fix: add bounds check in calc_constrained_cursor_pos to prevent index…

### DIFF
--- a/lua/oil/view.lua
+++ b/lua/oil/view.lua
@@ -264,6 +264,10 @@ end
 --- @return integer[] | nil
 local function calc_constrained_cursor_pos(bufnr, adapter, mode, cur)
   local parser = require("oil.mutator.parser")
+  local line_count = vim.api.nvim_buf_line_count(bufnr)
+  if cur[1] < 1 or cur[1] > line_count then
+    return
+  end
   local line = vim.api.nvim_buf_get_lines(bufnr, cur[1] - 1, cur[1], true)[1]
   local column_defs = columns.get_supported_columns(adapter)
   local result = parser.parse_line(adapter, line, column_defs)


### PR DESCRIPTION
… out of bounds

   When buffer content changes during async re-rendering (e.g. loading
   animation replacing directory listing), CursorMoved/ModeChanged autocmds
   can fire before the cursor position is adjusted to the new buffer line
   count. This causes nvim_buf_get_lines with strict_indexing=true to throw
   "Index out of bounds" at view.lua:267.

   Add a line count check before accessing buffer lines so that
   calc_constrained_cursor_pos returns nil when the cursor is beyond the
   buffer, letting Neovim clamp the cursor on its own.
   
   
<img width="1332" height="132" alt="image" src="https://github.com/user-attachments/assets/68a7a495-223c-457c-a757-e618c2884531" />
