### PR TITLE
fix: don't disable netrw entirely (breaks spell-file downloads)

### DIFF
--- a/lua/oil/init.lua
+++ b/lua/oil/init.lua
@@ -1201,12 +1201,24 @@ M.setup = function(opts)
   local aug = vim.api.nvim_create_augroup("Oil", {})
 
   if config.default_file_explorer then
-    vim.g.loaded_netrw = 1
-    vim.g.loaded_netrwPlugin = 1
-    -- If netrw was already loaded, clear this augroup
-    if vim.fn.exists("#FileExplorer") then
-      vim.api.nvim_create_augroup("FileExplorer", { clear = true })
+    -- Stop netrw from taking over directory buffers without disabling it entirely.
+    -- Setting g:loaded_netrw / g:loaded_netrwPlugin (the previous approach) blocked
+    -- unrelated netrw functionality like spell-file downloads, :Nread, gx, and
+    -- remote-URL editing. See #483.
+    local function clear_file_explorer()
+      if vim.fn.exists("#FileExplorer") == 1 then
+        vim.api.nvim_create_augroup("FileExplorer", { clear = true })
+      end
     end
+    clear_file_explorer()
+    -- netrw's runtime plugin loads after init.lua but before files are opened, so
+    -- clear again on VimEnter to catch the augroup it registers then.
+    vim.api.nvim_create_autocmd("VimEnter", {
+      desc = "Clear netrw FileExplorer augroup so oil owns directory buffers",
+      group = aug,
+      once = true,
+      callback = clear_file_explorer,
+    })
   end
 
   local patterns = {}

--- a/tests/regression_spec.lua
+++ b/tests/regression_spec.lua
@@ -145,4 +145,20 @@ a.describe("regression tests", function()
     end, 10)
     assert.equals("a.txt", vim.fn.expand("%:t"))
   end)
+
+  -- https://github.com/stevearc/oil.nvim/issues/483
+  -- Oil used to disable netrw entirely (g:loaded_netrw / g:loaded_netrwPlugin),
+  -- which blocked spell-file downloads, `:Nread`, `gx`, and other netrw features
+  -- that are unrelated to directory browsing. Clearing only the FileExplorer
+  -- augroup is enough to keep oil in charge of directory buffers.
+  a.it("does not disable netrw plugin entirely", function()
+    assert.not_equals(1, vim.g.loaded_netrw)
+    assert.not_equals(1, vim.g.loaded_netrwPlugin)
+    if vim.fn.exists("#FileExplorer") == 1 then
+      assert.equals(
+        "--- Autocommands ---",
+        vim.trim(vim.api.nvim_exec2("autocmd FileExplorer", { output = true }).output)
+      )
+    end
+  end)
 end)


### PR DESCRIPTION
Closes #483.

`oil.setup()` set `g:loaded_netrw` / `g:loaded_netrwPlugin` to keep netrw from taking over directory buffers. That also blocks unrelated netrw plumbing that the runtime depends on:

- `spellfile#LoadFile` uses netrw's `:Nread` to fetch missing spell files, so `:set spelllang=es` shows "Cannot find word list" instead of the download prompt.
- `gx`, `scp://`, `http://` editing, and other netrw integrations silently break.

Oil's `BufAdd` handler renames directory buffers to `oil://` form, which makes every netrw `isdirectory()` check return false on its own. Clearing netrw's `FileExplorer` augroup (the only thing netrw uses to take over directory buffers) is enough; the `loaded_netrw` flags were redundant.

The clear runs synchronously at `oil.setup()` time (covers the case where netrw was already loaded before oil) and again on a one-shot `VimEnter` autocmd (covers the common case where netrw's runtime plugin loads after `init.lua` but before files are opened).

Includes a regression test that fails on the previous code and passes here.