### PR TITLE
doc: add installation instructions via vim.pack

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,17 @@ call dein#add('stevearc/oil.nvim')
 </details>
 
 <details>
+  <summary>vim.pack (Neovim 0.12+)</summary>
+
+```lua
+vim.pack.add({
+    'https://github.com/stevearc/oil.nvim',
+})
+```
+
+</details>
+
+<details>
   <summary>Pathogen</summary>
 
 ```sh


### PR DESCRIPTION
As of version 0.12, Neovim now has a built in plugin manager. Simply added it to the list. 👍🏽 