### PR TITLE
Preview size option (+ fix)

### DIFF
--- a/lua/oil/config.lua
+++ b/lua/oil/config.lua
@@ -145,6 +145,8 @@ local default_config = {
   },
   -- Configuration for the file preview window
   preview_win = {
+    -- preview split size: size of the preview window (fraction of the whole window)
+    preview_size = 0.5,
     -- Whether the preview window is automatically updated when the cursor is moved
     update_on_cursor_moved = true,
     -- How to open the preview window "load"|"scratch"|"fast_scratch"
@@ -352,6 +354,7 @@ local M = {}
 ---| '"fast_scratch"' # Put only the visible text into a scratch buffer
 
 ---@class (exact) oil.PreviewWindowConfig
+---@field preview_size number
 ---@field update_on_cursor_moved boolean
 ---@field preview_method oil.PreviewMethod
 ---@field disable_preview fun(filename: string): boolean

--- a/lua/oil/init.lua
+++ b/lua/oil/init.lua
@@ -490,7 +490,7 @@ M.open_preview = function(opts, callback)
   if util.is_floating_win() then
     if preview_win == nil then
       local root_win_opts, preview_win_opts =
-        layout.split_window(0, config.float.preview_split, config.float.padding)
+        layout.split_window(0, config.float.preview_split, config.float.padding, config.preview_win.preview_size)
 
       local win_opts_oil = {
         relative = "editor",
@@ -592,6 +592,15 @@ M.open_preview = function(opts, callback)
     -- BufReadCmd to load the buffer. So we need to do it manually.
     if util.is_oil_bufnr(filebufnr) then
       M.load_oil_buffer(filebufnr)
+    end
+
+    -- Set preview window size if the window is not floating
+    if config.preview_win.preview_size and not util.is_floating_win() then
+      if opts.vertical then
+        vim.api.nvim_win_set_width(0, math.floor(vim.o.columns * config.preview_win.preview_size))
+      else
+        vim.api.nvim_win_set_height(0, math.floor(vim.o.lines * config.preview_win.preview_size))
+      end
     end
 
     vim.api.nvim_set_option_value("previewwindow", true, { scope = "local", win = 0 })

--- a/lua/oil/layout.lua
+++ b/lua/oil/layout.lua
@@ -172,13 +172,13 @@ M.split_window = function(winid, direction, gap)
   end
 
   if direction == "left" then
-    dim_root.col = dim_root.col + dim_root.width + gap
+    dim_root.col = dim_root.col + dim_new.width + gap
   elseif direction == "right" then
-    dim_new.col = dim_new.col + dim_new.width + gap
+    dim_new.col = dim_root.col + dim_root.width + gap
   elseif direction == "above" then
-    dim_root.row = dim_root.row + dim_root.height + gap
+    dim_root.row = dim_root.row + dim_new.height + gap
   elseif direction == "below" then
-    dim_new.row = dim_new.row + dim_new.height + gap
+    dim_new.row = dim_root.row + dim_root.height + gap
   end
 
   return dim_root, dim_new

--- a/lua/oil/layout.lua
+++ b/lua/oil/layout.lua
@@ -141,12 +141,14 @@ end
 ---@param winid integer
 ---@param direction "above"|"below"|"left"|"right"|"auto"
 ---@param gap integer
+---@param new_window_fraction number
 ---@return oil.WinLayout root_dim New dimensions of the original window
 ---@return oil.WinLayout new_dim New dimensions of the new window
-M.split_window = function(winid, direction, gap)
+M.split_window = function(winid, direction, gap, new_window_fraction)
   if direction == "auto" then
     direction = vim.o.splitright and "right" or "left"
   end
+  new_window_fraction = new_window_fraction or 0.5
 
   local float_config = vim.api.nvim_win_get_config(winid)
   ---@type oil.WinLayout
@@ -164,11 +166,11 @@ M.split_window = function(winid, direction, gap)
   local dim_new = vim.deepcopy(dim_root)
 
   if direction == "left" or direction == "right" then
-    dim_new.width = math.floor(float_config.width / 2) - math.ceil(gap / 2)
-    dim_root.width = dim_new.width
+    dim_root.width = math.floor((float_config.width - gap) * (1 - new_window_fraction))
+    dim_new.width = float_config.width - gap - dim_root.width
   else
-    dim_new.height = math.floor(float_config.height / 2) - math.ceil(gap / 2)
-    dim_root.height = dim_new.height
+    dim_root.height = math.floor((float_config.height - gap) * (1 -new_window_fraction))
+    dim_new.height = float_config.height - gap - dim_root.height
   end
 
   if direction == "left" then


### PR DESCRIPTION
I wanted to be able to configure the split for preview, as it is 1:1 by default and seemingly not easy to change.

- Adds preview_size option to preview_win. 
- Also found a bug in split_window function used for floating window, which wasn't affecting anything because the split is 1:1 only. 