### PR TITLE
fix: support nightly `:restart`

### DIFF
--- a/lua/oil/init.lua
+++ b/lua/oil/init.lua
@@ -810,6 +810,12 @@ local function maybe_hijack_directory_buffer(bufnr)
   if bufname == "" then
     return false
   end
+  if vim.v.startreason == "restart" then
+    if vim.fn.isdirectory(bufname) == 1 then
+      vim.api.nvim_buf_delete(bufnr, {})
+    end
+    return false
+  end
   if util.parse_url(bufname) or vim.fn.isdirectory(bufname) == 0 then
     return false
   end


### PR DESCRIPTION
Oil conflicts with the newly reworked `:restart` neovim/neovim#40321

https://github.com/user-attachments/assets/0992978c-ee3a-4502-916a-cdce6e42d9c7


