### PR TITLE
fix: add AIX ls fallback for ls in oil-ssh

### DIFF
--- a/lua/oil/adapters/ssh/connection.lua
+++ b/lua/oil/adapters/ssh/connection.lua
@@ -305,7 +305,9 @@ function SSHConnection:_consume()
         -- HACK: Sleep briefly to help reduce stderr/stdout interleaving.
         -- I want to find a way to flush the stderr before the echo DONE, but haven't yet.
         -- This was causing issues when ls directory that doesn't exist (b/c ls prints error)
-        'echo "===BEGIN==="; ' .. cmd.cmd .. '; CODE=$?; sleep .01; echo "===DONE($CODE)==="\r'
+        'echo "===BEGIN==="; '
+          .. cmd.cmd
+          .. '; CODE=$?; sleep .01 2>/dev/null; echo "===DONE($CODE)==="\r'
       )
     end
   end

--- a/lua/oil/adapters/ssh/sshfs.lua
+++ b/lua/oil/adapters/ssh/sshfs.lua
@@ -7,6 +7,7 @@ local util = require("oil.util")
 ---@class (exact) oil.sshFs
 ---@field new fun(url: oil.sshUrl): oil.sshFs
 ---@field conn oil.sshConnection
+---@field aix_compatible_ls? boolean
 local SSHFS = {}
 
 local FIELD_TYPE = constants.FIELD_TYPE
@@ -101,6 +102,33 @@ function SSHFS:open_terminal()
   self.conn:open_terminal()
 end
 
+---@param options string
+---@param path_postfix string
+---@param stderr_postfix string
+---@param callback fun(err: nil|string, lines: nil|string[])
+function SSHFS:_run_ls(options, path_postfix, stderr_postfix, callback)
+  local function run(aix_compatible)
+    local color_option = aix_compatible and "" or " --color=never"
+    self.conn:run(
+      string.format("LC_ALL=C ls %s%s%s%s", options, color_option, path_postfix, stderr_postfix),
+      function(err, lines)
+        if
+          err
+          and not aix_compatible
+          and (err:match("illegal option") or err:match("unrecognized option"))
+        then
+          self.aix_compatible_ls = true
+          run(true)
+        else
+          callback(err, lines)
+        end
+      end
+    )
+  end
+
+  run(self.aix_compatible_ls == true)
+end
+
 function SSHFS:realpath(path, callback)
   local cmd = string.format(
     'if ! readlink -f "%s" 2>/dev/null; then [[ "%s" == /* ]] && echo "%s" || echo "$PWD/%s"; fi',
@@ -119,24 +147,21 @@ function SSHFS:realpath(path, callback)
     if vim.endswith(abspath, ".") then
       abspath = abspath:sub(1, #abspath - 1)
     end
-    self.conn:run(
-      string.format("LC_ALL=C ls -land --color=never %s", shellescape(abspath)),
-      function(ls_err, ls_lines)
-        local type
-        if ls_err then
-          -- If the file doesn't exist, treat it like a not-yet-existing directory
-          type = "directory"
-        else
-          assert(ls_lines)
-          local _
-          _, type = parse_ls_line(ls_lines[1])
-        end
-        if type == "directory" then
-          abspath = util.addslash(abspath)
-        end
-        callback(nil, abspath)
+    self:_run_ls("-land", string.format(" %s", shellescape(abspath)), "", function(ls_err, ls_lines)
+      local type
+      if ls_err then
+        -- If the file doesn't exist, treat it like a not-yet-existing directory
+        type = "directory"
+      else
+        assert(ls_lines)
+        local _
+        _, type = parse_ls_line(ls_lines[1])
       end
-    )
+      if type == "directory" then
+        abspath = util.addslash(abspath)
+      end
+      callback(nil, abspath)
+    end)
   end)
 end
 
@@ -150,7 +175,7 @@ function SSHFS:list_dir(url, path, callback)
   if path ~= "" then
     path_postfix = string.format(" %s", shellescape(path))
   end
-  self.conn:run("LC_ALL=C ls -lan --color=never" .. path_postfix, function(err, lines)
+  self:_run_ls("-lan", path_postfix, "", function(err, lines)
     if err then
       if err:match("No such file or directory%s*$") then
         -- If the directory doesn't exist, treat the list as a success. We will be able to traverse
@@ -183,31 +208,28 @@ function SSHFS:list_dir(url, path, callback)
     if any_links then
       -- If there were any soft links, then we need to run another ls command with -L so that we can
       -- resolve the type of the link target
-      self.conn:run(
-        "LC_ALL=C ls -naLl --color=never" .. path_postfix .. " 2> /dev/null",
-        function(link_err, link_lines)
-          -- Ignore exit code 1. That just means one of the links could not be resolved.
-          if link_err and not link_err:match("^1:") then
-            return callback(link_err)
-          end
-          assert(link_lines)
-          for _, line in ipairs(link_lines) do
-            if line ~= "" and not line:match("^total") then
-              local ok, name, type, meta = pcall(parse_ls_line, line)
-              if ok and name ~= "." and name ~= ".." then
-                local cache_entry = entries[name]
-                if cache_entry[FIELD_TYPE] == "link" then
-                  cache_entry[FIELD_META].link_stat = {
-                    type = type,
-                    size = meta.size,
-                  }
-                end
+      self:_run_ls("-naLl", path_postfix, " 2> /dev/null", function(link_err, link_lines)
+        -- Ignore exit code 1. That just means one of the links could not be resolved.
+        if link_err and not link_err:match("^1:") then
+          return callback(link_err)
+        end
+        assert(link_lines)
+        for _, line in ipairs(link_lines) do
+          if line ~= "" and not line:match("^total") then
+            local ok, name, type, meta = pcall(parse_ls_line, line)
+            if ok and name ~= "." and name ~= ".." then
+              local cache_entry = entries[name]
+              if cache_entry[FIELD_TYPE] == "link" then
+                cache_entry[FIELD_META].link_stat = {
+                  type = type,
+                  size = meta.size,
+                }
               end
             end
           end
-          callback(nil, cache_entries)
         end
-      )
+        callback(nil, cache_entries)
+      end)
     else
       callback(nil, cache_entries)
     end

--- a/tests/sshfs_spec.lua
+++ b/tests/sshfs_spec.lua
@@ -1,0 +1,61 @@
+local sshfs = require("oil.adapters.ssh.sshfs")
+
+describe("oil-ssh filesystem", function()
+  it("falls back to an AIX-compatible ls command and caches the result", function()
+    local commands = {}
+    local responses = {
+      { "2: ls: illegal option -- -" },
+      { nil, { "aix output" } },
+      { nil, { "cached output" } },
+    }
+    local fs = setmetatable({
+      conn = {
+        run = function(_, command, callback)
+          table.insert(commands, command)
+          callback(unpack(table.remove(responses, 1)))
+        end,
+      },
+    }, { __index = sshfs })
+
+    local err, lines
+    fs:_run_ls("-lan", " '/tmp'", "", function(ls_err, ls_lines)
+      err, lines = ls_err, ls_lines
+    end)
+
+    assert.is_nil(err)
+    assert.same({ "aix output" }, lines)
+    assert.same({
+      "LC_ALL=C ls -lan --color=never '/tmp'",
+      "LC_ALL=C ls -lan '/tmp'",
+    }, commands)
+
+    fs:_run_ls("-lan", " '/var'", "", function(ls_err, ls_lines)
+      err, lines = ls_err, ls_lines
+    end)
+
+    assert.is_nil(err)
+    assert.same({ "cached output" }, lines)
+    assert.equals("LC_ALL=C ls -lan '/var'", commands[3])
+  end)
+
+  it("keeps using GNU ls when it succeeds", function()
+    local command
+    local fs = setmetatable({
+      conn = {
+        run = function(_, value, callback)
+          command = value
+          callback(nil, { "gnu output" })
+        end,
+      },
+    }, { __index = sshfs })
+
+    local lines
+    fs:_run_ls("-land", " '.'", "", function(_, ls_lines)
+      lines = ls_lines
+    end)
+
+    assert.equals("LC_ALL=C ls -land --color=never '.'", command)
+    assert.same({ "gnu output" }, lines)
+    assert.is_nil(fs.aix_compatible_ls)
+  end)
+end)


### PR DESCRIPTION
- I often work on AIX machines, which has a different version of ls
- this patch still defaults to GNU ls, unless it fails, in which case it defaults to AIX ls
- I have tested this, and it does work now